### PR TITLE
Fix feedhenry/fh-db#6 : CSV import of columns surrounded w/ quotes

### DIFF
--- a/lib/importexport/csv.js
+++ b/lib/importexport/csv.js
@@ -6,7 +6,9 @@ exports.importer = function(csvString, cb){
     csvString = csvString.toString();
   }
   var Converter = csvtojson.core.Converter;
-  var csvConverter = new Converter({constructResult:true, quote : undefined});
+  // use " char as the char that may surround columns
+  // see CSV spec : https://tools.ietf.org/html/rfc4180
+  var csvConverter = new Converter({constructResult:true, quote: '"'});
   var parserMgr = csvtojson.core.parserMgr;
   parserMgr.addParser("typeTransformer",/./,function (params){
 
@@ -33,7 +35,7 @@ exports.importer = function(csvString, cb){
      params.resultRow[params.head]= params.item;
   });
 
-  csvConverter.fromString(csvString);
+  // let's add the event handler before starting the conversion
   csvConverter.on("end_parsed", function(jsonObj) {
     if (!jsonObj) {
       return cb("Error parsing CSV");
@@ -43,6 +45,8 @@ exports.importer = function(csvString, cb){
     }
     return cb(null, jsonObj);
   });
+
+  csvConverter.fromString(csvString);
 };
 
 exports.exporter = function(jsonArray, cb){

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-db",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "dependencies": {
     "adm-zip": {
       "version": "0.4.7",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-db",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "dependencies": {
     "adm-zip": {
       "version": "0.4.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-db",
   "description": "FeedHenry Database Library",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "repository": {
     "type": "git",
     "url": "git@github.com:feedhenry/fh-db.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-db",
   "description": "FeedHenry Database Library",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "repository": {
     "type": "git",
     "url": "git@github.com:feedhenry/fh-db.git"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-db
 sonar.projectName=fh-db-nightly-master
-sonar.projectVersion=1.1.0
+sonar.projectVersion=1.1.1
 
 sonar.sources=./lib
 sonar.tests=./test

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-db
 sonar.projectName=fh-db-nightly-master
-sonar.projectVersion=1.1.1
+sonar.projectVersion=1.1.2
 
 sonar.sources=./lib
 sonar.tests=./test

--- a/test/importexport/test_csv.js
+++ b/test/importexport/test_csv.js
@@ -1,0 +1,57 @@
+/*
+ * Some code testing the CSV converting functionality.
+ *
+ */
+
+var assert = require("assert");
+
+var csvImporter = require("../../lib/importexport/csv").importer;
+
+exports['should convert simple csv to json'] = function () {
+  var str = "";
+  str += "a,b,c" + "\n";
+  str += "1,2,3" + "\n";
+  str += "4,5,6" + "\n";
+
+  csvImporter(str, function (err, json) {
+    assert.isNull(err);
+    assert.deepEqual(json, [{a: 1, b: 2, c: 3}, {a: 4, b: 5, c: 6}]);
+  });
+};
+
+exports['should convert csv to json w/o EOL at the end'] = function () {
+  var str = "";
+  str += "a,b,c" + "\n";
+  str += "1,2,3" + "\n";
+  str += "4,5,6";
+
+  csvImporter(str, function (err, json) {
+    assert.isNull(err);
+    assert.deepEqual(json, [{a: 1, b: 2, c: 3}, {a: 4, b: 5, c: 6}]);
+  });
+};
+
+exports['should convert csv to json w/ unquoted strings '] = function () {
+  var str = "";
+  str += "a,b,c" + "\n";
+  str += "1,2,3" + "\n";
+  str += "x,y,z" + "\n";
+
+  csvImporter(str, function (err, json) {
+    assert.isNull(err);
+    assert.deepEqual(json, [{a: 1, b: 2, c: 3}, {a: "x", b: "y", c: "z"}]);
+  });
+};
+
+exports['should convert csv to json w/ quotes'] = function () {
+  var str = "";
+  str += "a,b,c" + "\n";
+  str += "1,2,3" + "\n";
+  str += "4,5,6" + "\n";
+  str += '"x,p","y",z' + "\n";
+
+  csvImporter(str, function (err, json) {
+    assert.isNull(err);
+    assert.deepEqual(json, [{a: 1, b: 2, c: 3}, {a: 4, b: 5, c: 6}, {a: "x,p", b: "y", c: "z"}]);
+  });
+};


### PR DESCRIPTION
* CSV importer uses csvtojson
* csvtojson takes a parameter called "quote" to identify if there is a character that may surround columns
* This parameter was passed as undefined which is probably thought of using default value. However, it simply causes csvtojson to not use any character.
* Changed that quote parameter to " so that quote will be used as defined in the CSV spec

Before doing the code change, I wrote some characterization tests for the module that converts CSV to JSON. As there were no tests before, I wanted to make sure basic functionality is unchanged after fixing the bug.

I wrote a test case for the requirement which was failing: I've verified that columns were split even though they were surrounded with quote chars.

Fixed the problem: test started passing.
