### PR TITLE
Rhmap 9815

### DIFF
--- a/lib/localdb.js
+++ b/lib/localdb.js
@@ -1,6 +1,7 @@
 var fhdb = require('./fhmongodb.js');
 var fhditcher = require('./ditcher.js');
 var assert = require('assert');
+var permission_map = require('./permission_map');
 
 var ditch;
 
@@ -160,62 +161,65 @@ var local_db = function (params, cb) {
       return cb(err);
     }
     my_db_logger.debug("DBACTION: " + action);
-    if ('create' === action) {
+
+    // Using the `name` property from the permission map here to make
+    // sure this one gets updated as new actions are added.
+    if (permission_map.db.create.name === action) {
       my_db_logger.debug('about to: create');
       ditch.doCreate(params, function (err, id) {
         my_db_logger.debug('back from create: err', err, "id:", id);
         if (err) return cb(err);
         return cb(undefined, id);
       });
-    } else if ('list' === action) {
+    } else if (permission_map.db.list.name === action) {
       ditch.doList(params, function (err, id) {
         if (err) return cb(err);
         var listResp = {count: id.length, list: id};
         return cb(undefined, listResp);
       });
-    } else if ('read' === action) {
+    } else if (permission_map.db.read.name === action) {
       my_db_logger.debug('about to: read, params: ', params);
       ditch.doRead(params, function (err, doc) {
         my_db_logger.debug('back from create: err', err, "doc:", doc);
         if (err) return cb(err);
         return cb(undefined, doc);
       });
-    } else if ('delete' === action) {
+    } else if (permission_map.db.delete.name === action) {
       ditch.doDelete(params, function (err, doc) {
         if (err) return cb(err);
         return cb(undefined, doc);
       });
-    } else if ('deleteall' === action) {
+    } else if (permission_map.db.deleteAll.name === action) {
       ditch.doDeleteAll(params, function (err, doc) {
         if (err) return cb(err);
         return cb(undefined, doc);
       });
-    } else if ('drop' === action) {
+    } else if (permission_map.db.drop.name === action) {
       ditch.doDropCollection(params, function(err, doc) {
         if (err) return cb(err);
         return cb(undefined, doc);
       });
-    } else if ('update' === action) {
+    } else if (permission_map.db.update.name === action) {
       ditch.doUpdate(params, function (err, doc) {
         if (err) return cb(err);
         return cb(undefined, doc);
       });
-    } else if ('index' === action) {
+    } else if (permission_map.db.index.name === action) {
       ditch.doIndex(params, function (err, doc) {
         if (err) return cb(err);
         return cb(undefined, doc);
       });
-    } else if ('export' === action) {
+    } else if (permission_map.db.export.name === action) {
       ditch.doExport(params, function (err, zip) {
         if (err) return cb(err);
         return cb(undefined, zip);
       });
-    } else if ('import' === action) {
+    } else if (permission_map.db.import.name === action) {
       ditch.doImport(params, function (err, doc) {
         if (err) return cb(err);
         return cb(undefined, doc);
       });
-    } else if ('close' === action) {
+    } else if (permission_map.db.close.name === action) {
       tearDownDitch();
       return cb();
     }else {
@@ -251,3 +255,4 @@ exports.tearDownDitch = tearDownDitch;
 exports.Ditcher = fhditcher.Ditcher;
 exports.Database = fhdb.Database;
 exports.parseMongoConnectionURL = parseMongoConnectionURL;
+exports.permission_map = permission_map;

--- a/lib/permission_map.js
+++ b/lib/permission_map.js
@@ -1,0 +1,54 @@
+/**
+ * Defines the permissions that are required for the various
+ * db actions. This became neccessary because at the moment all actions
+ * in databrowser require `write` permissions but we want more fine grained
+ * control. In the future this map could also be used for e.g. forms actions.
+ */
+module.exports = {
+  db: {
+    create: {
+      name: "create",
+      requires: "write"
+    },
+    list: {
+      name: "list",
+      requires: "read"
+    },
+    read: {
+      name: "read",
+      requires: "read"
+    },
+    delete: {
+      name: "delete",
+      requires: "write"
+    },
+    deleteAll: {
+      name: "deleteall",
+      requires: "write"
+    },
+    drop: {
+      name: "drop",
+      requires: "write"
+    },
+    update: {
+      name: "update",
+      requires: "write"
+    },
+    index: {
+      name: "index",
+      requires: "read"
+    },
+    export: {
+      name: "export",
+      requires: "read"
+    },
+    import: {
+      name: "import",
+      requires: "write"
+    },
+    close: {
+      name: "close",
+      requires: "read"
+    }
+  }
+};

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-db",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "dependencies": {
     "adm-zip": {
       "version": "0.4.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-db",
   "description": "FeedHenry Database Library",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "repository": {
     "type": "git",
     "url": "git@github.com:feedhenry/fh-db.git"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-db
 sonar.projectName=fh-db-nightly-master
-sonar.projectVersion=1.2.1
+sonar.projectVersion=1.2.2
 
 sonar.sources=./lib
 sonar.tests=./test

--- a/test/test_permissions.js
+++ b/test/test_permissions.js
@@ -1,0 +1,28 @@
+var assert = require("assert");
+var permission_map = require('../lib/permission_map');
+
+exports['test permission map present'] = function() {
+  assert.ok(permission_map);
+  assert.ok(permission_map.db);
+  assert.ok(permission_map.db.create);
+  assert.ok(permission_map.db.list);
+  assert.ok(permission_map.db.delete);
+  assert.ok(permission_map.db.deleteAll);
+  assert.ok(permission_map.db.drop);
+  assert.ok(permission_map.db.update);
+  assert.ok(permission_map.db.export);
+  assert.ok(permission_map.db.import);
+  assert.ok(permission_map.db.close);
+};
+
+exports['test default permissions'] = function() {
+  assert.ok(permission_map.db.create.requires === "write");
+  assert.ok(permission_map.db.list.requires === "read");
+  assert.ok(permission_map.db.delete.requires === "write");
+  assert.ok(permission_map.db.deleteAll.requires === "write");
+  assert.ok(permission_map.db.drop.requires === "write");
+  assert.ok(permission_map.db.update.requires === "write");
+  assert.ok(permission_map.db.export.requires === "read");
+  assert.ok(permission_map.db.import.requires === "write");
+  assert.ok(permission_map.db.close.requires === "read");
+};


### PR DESCRIPTION
# Motivation

we want to introduce a permission map to fh-db. At the moment all requests are only authenticated based on the business object. But we want to be able to differ between `read` and `write` permissions for the various db actions. In the future this could also be used for the forms actions.

ping @wei-lee @ziccardi @aliok 