### PR TITLE
RHMAP-9849 documents w/ custom id

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,7 @@ Add fh-db as a dependency to your module and require it where required, like any
 ### Start Mongo Server
 Start the docker machine for the version of mongo you wish to test:
 ```bash
-docker run -d -p 27017:27017 mongo:2.4
-# or (preferred)
 docker run -d -p 27017:27017 mongo:2.6
-# or
-...
 ```
 
 ### Note for docker-machine users
@@ -56,8 +52,9 @@ connect to Mongo:
 mongo
 ```
 
-#### For versions > 3.x
-You will need to update the authentication to work with fh-db, which is done as follows:
+#### For MongoDB versions > 3.x
+Well, instead of MongoDB 2.6 stated above if you used MongoDB 3.x, you will need to update the authentication
+to work with fh-db, which is done as follows:
 ```
 use admin
 db.system.users.remove({})
@@ -77,12 +74,7 @@ mongo
 ```
 
 #### Add the admin user:
-##### 2.4.x
-```
-use admin
-db.addUser('admin', 'admin');
-```
-##### >= 2.6
+
 ```
 use admin
 db.createUser({user: 'admin', pwd: 'admin', roles: ['root']})
@@ -97,13 +89,7 @@ mongo admin -u admin -p admin
 #### Add the ditchuser
 
 Log in as the admin user, if you are not yet, then run:
-##### 2.4.x
-```
-use fh-ditch
-db.addUser('ditchuser', 'ditchpassword');
-```
 
-##### >= 2.6
 ```
 use fh-ditch
 db.createUser({user: 'ditchuser', pwd: 'ditchpassword', roles: ['dbAdmin']})

--- a/README.md
+++ b/README.md
@@ -31,18 +31,22 @@ Add fh-db as a dependency to your module and require it where required, like any
 Start the docker machine for the version of mongo you wish to test:
 ```bash
 docker run -d -p 27017:27017 mongo:2.4
+# or (preferred)
+docker run -d -p 27017:27017 mongo:2.6
+# or
+...
 ```
 
 ### Note for docker-machine users
 You will need to connect your localhost:27017 to the docker-machine:27017, do this with the following command:
 ```
-VBoxManage controlvm <docker-machine-name> natpf1 "docker-mongo,tcp,127.0.0.1,27017,,27017"
+VBoxManage controlvm `docker-machine active` natpf1 "docker-mongo,tcp,127.0.0.1,27017,,27017"
 ```
 In the above `docker-mongo` is the name of the rule, this is important to remember, in order to remove it when not required.
 
 Remove the above rule as follows:
 ```
-VBoxManage controlvm dev natpf1 delete docker-mongo
+VBoxManage controlvm `docker-machine active` natpf1 delete docker-mongo
 ```
 
 

--- a/lib/ditcher.js
+++ b/lib/ditcher.js
@@ -354,7 +354,8 @@ Ditcher.prototype.doRead = function (params, callback) {
   try {
     query = {"_id": self.database.createObjectIdFromHexString(params.guid)};
   } catch (err) {
-    return callback(new Error('Error creating ObjectId from string: ' + JSON.stringify(err)));
+    // if the guid passed is not a hex ObjectID, use it as is
+    query = {"_id": params.guid};
   }
   self.logger.debug("Ditcher.read/query: " + JSON.stringify(query));
 
@@ -395,7 +396,8 @@ Ditcher.prototype.doUpdate = function (params, callback) {
   try {
     criteria = {"_id": self.database.createObjectIdFromHexString(params.guid)};
   } catch (err) {
-    return callback(new Error('Error creating ObjectId from string: ' + JSON.stringify(err)));
+    // if the guid passed is not a hex ObjectID, use it as is
+    criteria = {"_id": params.guid};
   }
   self.logger.debug("Ditcher.update/criteria: " + JSON.stringify(criteria));
 

--- a/lib/fhmongodb.js
+++ b/lib/fhmongodb.js
@@ -303,7 +303,9 @@ Database.prototype.remove = function (collectionName, id, callback) {
   var self = this;
 
   this.db.collection(collectionName, function (err, collection) {
-    if (null !== err) return callback(err, null);
+    if (null !== err){
+      return callback(err, null);
+    }
 
     // if a GUID id is passed as strings, convert it to an ObjectID 
     try{
@@ -386,7 +388,9 @@ Database.prototype.countCollection = function (collectionName, callback) {
   if (null === this.db) return callback(new Error("no database open"), null);
 
   this.db.collection(collectionName, function (err, collection) {
-    if (err) return callback(err, null);
+    if (err){
+      return callback(err, null);
+    }
     collection.count(callback);
   });
 };

--- a/lib/fhmongodb.js
+++ b/lib/fhmongodb.js
@@ -307,7 +307,7 @@ Database.prototype.remove = function (collectionName, id, callback) {
       return callback(err, null);
     }
 
-    // if a GUID id is passed as strings, convert it to an ObjectID 
+    // if a GUID id is passed as strings, convert it to an ObjectID
     try{
       id = self.createObjectIdFromHexString(id);
     }catch(err){

--- a/lib/fhmongodb.js
+++ b/lib/fhmongodb.js
@@ -305,8 +305,15 @@ Database.prototype.remove = function (collectionName, id, callback) {
   this.db.collection(collectionName, function (err, collection) {
     if (null !== err) return callback(err, null);
 
+    // if a GUID id is passed as strings, convert it to an ObjectID 
+    try{
+      id = self.createObjectIdFromHexString(id);
+    }catch(err){
+      // if not, use the id as is
+    }
+
     collection.remove({
-      _id: self.createObjectIdFromHexString(id)
+      _id: id
     }, function (err, docs) {
       return callback(err, docs);
     });

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-db",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "dependencies": {
     "adm-zip": {
       "version": "0.4.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-db",
   "description": "FeedHenry Database Library",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "repository": {
     "type": "git",
     "url": "git@github.com:feedhenry/fh-db.git"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-db
 sonar.projectName=fh-db-nightly-master
-sonar.projectVersion=1.2.2
+sonar.projectVersion=1.2.3
 
 sonar.sources=./lib
 sonar.tests=./test


### PR DESCRIPTION
Fixed the bug that was blocking the deletion and update of documents with ids that are not hex.

Before the PR, the delete and update calls were expecting hex values as the guid arguments.

Now, we try to convert the given argument to ObjectID and if it fails, we use the id as is.