### PR TITLE
Rhmap 11065 handle mongo restarts

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -176,18 +176,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2016 Red Hat, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/lib/fhmongodb.js
+++ b/lib/fhmongodb.js
@@ -153,13 +153,20 @@ Database.prototype.tearUp = function (auth) {
           if (interval) {
             clearInterval(interval);
           }
-          self.db = db.db(self.name);
-          authenticateUser(auth);
 
-          self.db.on('error', function (err) {
-            console.warn("mongodb emits error: " + err);
+          db.on('error', function (err) {
+            console.warn('Mongo connection error:'  + err);
             self.emit('error', err);
           });
+
+          db.on('close', function() {
+            var message = 'Mongo connection closed';
+            console.warn(message);
+            self.emit('close', message);
+          });
+
+          self.db = db.db(self.name);
+          authenticateUser(auth);
         }
       });
     } else {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-db",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "dependencies": {
     "adm-zip": {
       "version": "0.4.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-db",
   "description": "FeedHenry Database Library",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "repository": {
     "type": "git",
     "url": "git@github.com:feedhenry/fh-db.git"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-db
 sonar.projectName=fh-db-nightly-master
-sonar.projectVersion=1.2.3
+sonar.projectVersion=1.2.4
 
 sonar.sources=./lib
 sonar.tests=./test


### PR DESCRIPTION
### Motivation
Events were not being correctly emitted when there was an error with the connection to Mongo. Also, because some components dependent on fh-db need to listen for the close event, which was not being emitted, this was added 