### PR TITLE
Allow developers to use different port locally

### DIFF
--- a/lib/localdb.js
+++ b/lib/localdb.js
@@ -108,7 +108,7 @@ function getDitchHandle(cb) {
   var my_db_config = {
     database: {
       host: '127.0.0.1',
-      port: 27017,
+      port: process.env.FH_LOCAL_DB_PORT || 27017,
       name: 'FH_LOCAL'
     }
   };

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-db",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "dependencies": {
     "adm-zip": {
       "version": "0.4.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-db",
   "description": "FeedHenry Database Library",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "repository": {
     "type": "git",
     "url": "git@github.com:feedhenry/fh-db.git"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-db
 sonar.projectName=fh-db-nightly-master
-sonar.projectVersion=1.2.4
+sonar.projectVersion=1.2.5
 
 sonar.sources=./lib
 sonar.tests=./test


### PR DESCRIPTION
**Motivation**

We force developers to have mongo running on 27017. Some folks out there like running these things off custom ports 👎 
Small PR to introduce yet another environment variable that allows the developer to overwrite this. 

This will allow developers to update the Gruntfile we provide in the cloud app template to specify a custom port like so:
```
env: {
      options: {},
      // environment variables - see https://github.com/jsoverson/grunt-env for more information
      local: {
        FH_USE_LOCAL_DB: true,
        FH_LOCAL_DB_PORT: '122331',
        FH_SERVICE_MAP: function() {
          /*
           * Define the mappings for your services here - for local development.
           * You must provide a mapping for each service you wish to access
           * This can be a mapping to a locally running instance of the service (for local development)
           * or a remote instance.
           */
          var serviceMap = {
            'SERVICE_GUID_1': 'http://127.0.0.1:8010',
            'SERVICE_GUID_2': 'https://host-and-path-to-service'
          };
          return JSON.stringify(serviceMap);
        }
      }
    },
```