### PR TITLE
Rhmap 11672

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,7 +2,11 @@ module.exports = function(grunt) {
   'use strict';
 
   grunt.initConfig({
-    unit: 'expresso -I lib -q -c -b'
+    unit: [
+      'expresso -I lib -q -c -b',
+      'env DB_PER_APP=false mocha ./test/mocha/mocha_tst_mongo_compat_api.js',
+      'env DB_PER_APP=true mocha ./test/mocha/mocha_tst_mongo_compat_api.js'
+    ]
   });
 
   grunt.loadNpmTasks('grunt-fh-build');

--- a/lib/ditcher.js
+++ b/lib/ditcher.js
@@ -286,18 +286,9 @@ Ditcher.prototype.doList = function (params, callback) {
   });
 };
 
-Ditcher.prototype.doListCollections = function (params, callback) {
-  var self = this;
-
-  if (!params.__fhdb ||
-    (!params.__dbperapp && !appname_regex.test(params.__fhdb)) ||
-    (params.__dbperapp ===true && params.__fhdb !== self.database.name)) {
-    return callback(new Error("Incorrect parameters for listing collections"));
-  }
-
-  self.database.collectionNames(function (err, names) {
-    var getters = [],
-      i, curName, c, length, memory;
+function getListCollectionsHandler(self, params, callback) {
+  return function (err, names) {
+    var getters = [], i, curName;
     if (null !== err) {
       self.logger.debug("Ditcher.listCollections/result: err=" + err);
       return callback(err);
@@ -335,7 +326,19 @@ Ditcher.prototype.doListCollections = function (params, callback) {
       })(self, curName);
     }
     async.parallel(getters, callback);
-  });
+  };
+}
+
+Ditcher.prototype.doListCollections = function (params, callback) {
+  var self = this;
+
+  if (!params.__fhdb ||
+    (!params.__dbperapp && !appname_regex.test(params.__fhdb)) ||
+    (params.__dbperapp ===true && params.__fhdb !== self.database.name)) {
+    return callback(new Error("Incorrect parameters for listing collections"));
+  }
+
+  self.database.collectionNames(getListCollectionsHandler(this, params, callback));
 };
 
 Ditcher.prototype.doRead = function (params, callback) {
@@ -434,7 +437,6 @@ Ditcher.prototype.doIndex = function (params, callback) {
   self.database.index(coll, indexes, function (err, name) {
     callback(err, !err ? {"status": "OK", "indexName": name} : {"status": "ERROR"});
   });
-
 };
 
 Ditcher.prototype.doDelete = function (params, callback) {
@@ -613,6 +615,66 @@ Ditcher.prototype.doImport = function (params, cb) {
   });
 };
 
+// Renames a collection while keeping the naming conventions for
+// shared dbs intact
+Ditcher.prototype.doRenameCollection = function (params, callback) {
+  if (!checkParams(params)) {
+    return callback(new Error("Invalid Params"));
+  }
 
+  var fromColl = constructCollectionName(params);
+
+  // Need to switch the `type` parameter now because `constructCollectionName` expects
+  // that one to be the collection name
+  params.type = params.toCollection;
+  var toColl = constructCollectionName(params);
+
+  this.database.renameCollection(fromColl, toColl, params, callback);
+};
+
+// Returns a native MongoDB collection instance which can be used for update/insert/find
+// operations. This function adheres to the shared db naming conventions.
+Ditcher.prototype.doGetCollectionInstance = function (params, callback) {
+  if (!checkParams(params)) {
+    return callback(new Error("Invalid Params"));
+  }
+
+  if (params.type && params.type.length > MAX_COLLECTION_NAME) {
+    return callback("Error: 'type' name too long: '" + params.type + "'. Collection name cannot be greater than: " + MAX_COLLECTION_NAME);
+  }
+
+  var coll = constructCollectionName(params);
+  return this.database.getCollectionInstance(coll, params, callback);
+};
+
+// Returns a cursor that can be used for listing the collections. This function
+// adheres to the shared-db naming conventions. Also accepts a filter object to
+// filter the returned collections.
+Ditcher.prototype.doGetCollectionsListCursor = function (filter, params) {
+  var self = this;
+
+  if (!params.__fhdb) {
+    throw new Error("__fhdb parameter required for listing collections");
+  }
+
+  if (!params.__dbperapp && !appname_regex.test(params.__fhdb)) {
+    throw new Error("__fhdb database name is invalid");
+  }
+
+  if (params.__dbperapp ===true && params.__fhdb !== self.database.name) {
+    throw new Error("__fhdb parameter and database name inconsistent");
+  }
+
+  var cursor = self.database.listCollections(filter, params);
+
+  // MongoDB `CommandCursor` like object
+  function CommandCursor(cursor) {
+    this.toArray = function (callback) {
+      cursor.toArray(getListCollectionsHandler(self, params, callback));
+    };
+  }
+
+  return new CommandCursor(cursor);
+};
 
 exports.Ditcher = Ditcher;

--- a/lib/fhmongodb.js
+++ b/lib/fhmongodb.js
@@ -4,6 +4,8 @@ var MongoClient = mongodb.MongoClient;
 var ObjectID = mongodb.ObjectID;
 var util = require("util");
 var EventEmitter = require('events').EventEmitter;
+var parseConnectionUrl = require("./utils").parseConnectionUrl;
+var parseConnectionUrlOptions = require("./utils").parseConnectionUrlOptions;
 
 var Database = function (host, port, pDriverOptions, retryWaitTime, dbname) {
   EventEmitter.call(this);
@@ -27,98 +29,6 @@ var Database = function (host, port, pDriverOptions, retryWaitTime, dbname) {
 };
 
 util.inherits(Database, EventEmitter);
-
-
-/**
- * This will return a connection URL like:
- * host1[:port1][,host2[:port2],...[,hostN[:portN]]]
- *
- * With the intention that it can be prepended with "mongodb://[username]:[password]@"
- * and appended with "/[database][?options]
- *
- * @param host This is expected in the format: "host1" or "host1,host2" or ["host1", "host2"]
- * @param port This is expected in the format: 123 or "123" or "123,456" or ["123", "456"] or [123, 456]
- *
- * @returns {string} host1[:port1][,host2[:port2],...[,hostN[:portN]]]
- */
-function parseConnectionUrl(host, port){
-  var hosts = [];
-  var ports = [];
-
-  //normalise host to an array
-  if(! host) {
-    hosts  = ['localhost'];
-  } else if('string' === typeof host && host.split(',').length <= 1){
-    hosts = [host];
-  } else if ('string' === typeof host && host.split(',').length > 1){
-    hosts = host.split(',');
-  } else if (Array.isArray(host)){
-    hosts = host;
-  }
-
-  //normalise port to an array
-  if(! port){
-    ports = [27017];
-  } else if('string' === typeof port && port.split(',').length <= 1 || 'number' === typeof port){
-    ports = [port];
-  } else if ('string' === typeof port && port.split(',').length > 1){
-    ports = port.split(',');
-  } else if (Array.isArray(port)){
-    ports = port;
-  }
-
-  var connectionHosts = [];
-
-  for( var hostIndex=0; hostIndex < hosts.length; hostIndex++ ){
-    connectionHosts[hostIndex] = hosts[hostIndex];
-
-    //if only one port specified, use it on all hosts, otherwise assume number of ports and hosts are equal
-    if(ports.length === 1){
-      connectionHosts[hostIndex] += ":" + ports[0];
-    } else {
-      connectionHosts[hostIndex] += ":" + ports[hostIndex];
-    }
-  }
-
-  return connectionHosts.join(',');
-}
-
-
-/**
- * Returns the driver options URL encoded for the connection string; e.g.: w=1&j=true
- *
- * @param options an Array of options
- *
- * @returns {string}
- */
-function parseConnectionUrlOptions(options){
-  //set default values
-  var retOptions = { w: 1, j: true, numberOfRetries: 5, retryMiliSeconds: 2000, native_parser:false};
-
-  //override defaults
-  if (options) {
-    for (var field in options) {
-      // RHMAP-9817 if a field (more explicitly replicaSet) is empty don't include it in the options
-      // The reason that the comparator to an empty string was used is that the options[field] value can be set to false
-      // and hence not get included
-      if (options[field] !== "") {
-        retOptions[field] = options[field];
-      }
-    }
-  }
-  var argParts = [];
-
-  //convert options to arg string
-  for(var opt in retOptions) {
-    if (retOptions.hasOwnProperty(opt)) {
-      argParts.push(encodeURIComponent(opt) + "=" + encodeURIComponent(retOptions[opt]));
-    }
-  }
-  if(argParts.length) {
-    return "?" + argParts.join("&");
-  }
-  return "";
-}
 
 Database.prototype.createObjectIdFromHexString = function (str) {
   return ObjectID.createFromHexString(str);
@@ -209,6 +119,10 @@ Database.prototype.tearDown = function () {
   }
 
   this.emit('tearDown');
+};
+
+Database.prototype.close = function (force, callback) {
+  return this.db.close(force, callback);
 };
 
 Database.prototype.create = function (collectionName, data, callback) {
@@ -378,7 +292,7 @@ Database.prototype.createCollectionWithOptions = function (collectionName, optio
     if (err) {
       console.log("Error from createCollection(): " + JSON.stringify(err));
     }
-    return callback(err);
+    return callback(err, collection);
   });
 };
 
@@ -464,6 +378,21 @@ Database.prototype.index = function (collectionName, indexes, callback) {
   });
 };
 
+/**
+ * Same as `#index` but works on DB level instead of collection level. Also passes
+ * extra options parameter to the MongoDB driver
+ */
+Database.prototype.createIndex = function (name, fieldOrSpec, options, callback) {
+  if (!this.db) {
+    if (callback) {
+      return callback(new Error("no database open"));
+    }
+    throw new Error("no database open");
+  }
+
+  return this.db.createIndex(name, fieldOrSpec, options, callback);
+};
+
 Database.prototype.checkStatus = function (cb) {
   if (null == this.db) return cb(new Error("no database open"));
   this.db.collections(function (err, result) {
@@ -475,6 +404,56 @@ Database.prototype.checkStatus = function (cb) {
 Database.prototype.collection = function (name, cb) {
   if (null == this.db) return cb(new Error("no database open"));
   this.db.collection(name, cb);
+};
+
+// Same as `collection` but returns a collection instance if no callback is
+// passed and also accepts extra options
+Database.prototype.getCollectionInstance = function (name, options, callback) {
+  if (!this.db) {
+    if (callback) {
+      return callback(new Error("no database open"));
+    }
+    throw new Error("no database open");
+  }
+
+  return this.db.collection(name, options, callback);
+};
+
+Database.prototype.renameCollection = function (fromCollection, toCollection, options, callback) {
+  if (!this.db) {
+    if (callback) {
+      return callback(new Error("no database open"));
+    }
+    throw new Error("no database open");
+  }
+
+  return this.db.renameCollection(fromCollection, toCollection, options, callback);
+};
+
+// Raw MongoDB `listCollections` returning a CommandCursor like object
+Database.prototype.listCollections = function (filter, options) {
+  if (!this.db) {
+    throw new Error("no database open");
+  }
+
+  var cursor = this.db.listCollections(filter, options);
+  var databaseName = this.db.databaseName;
+
+  // MongoDB `CommandCursor` like object
+  function CommandCursor(cursor) {
+    this.toArray = function (callback) {
+      cursor.toArray(function (error, documents) {
+        documents = _.map(documents, function (document) {
+          return _.mapValues(document, function (val, key) {
+            return key === "name" ? databaseName + "." + val : val;
+          });
+        });
+        return callback(error, documents);
+      });
+    };
+  }
+
+  return new CommandCursor(cursor);
 };
 
 exports.Database = Database;

--- a/lib/localdb.js
+++ b/lib/localdb.js
@@ -2,105 +2,10 @@ var fhdb = require('./fhmongodb.js');
 var fhditcher = require('./ditcher.js');
 var assert = require('assert');
 var permission_map = require('./permission_map');
+var parseMongoConnectionURL = require('./utils').parseMongoConnectionURL;
+var my_db_logger = require("./logger");
 
 var ditch;
-
-
-//The mongo connection will be of the form mongodb://user:password@host:port/database
-function parseMongoConnectionURL(mongoConnectionURL) {
-  var result = {};
-
-  //The connection string will be of the form mongodb://user:password@host:port,host2port2/databasename?option=someOption
-  //String to break down the mongodb url into a ditch config hash
-  var auth_hosts_path_options = new Buffer(mongoConnectionURL).toString().split("//")[1];
-
-  //user:password , host:port,host2:port2/databasename?option=someOption
-  var auth = auth_hosts_path_options.split("@")[0];
-
-
-  var hosts_path_options = auth_hosts_path_options.split("@")[1];
-
-  // host:port,host2:port2/databasename , option=someOption
-  var hosts_path = hosts_path_options.split("?")[0];
-  var options = hosts_path_options.split("?")[1];
-
-  //host:port,host2:port2, databasename
-  var hosts = hosts_path.split("/")[0];
-  var databaseName = hosts_path.split("/")[1];
-
-  //host:port host2:port2
-  var hostList = hosts.split(",");
-
-  //user, password
-  var authUser = auth.split(":")[0];
-  var authPassword = auth.split(":")[1];
-
-  result.database = {};
-  result.database.driver_options = {};
-  result.database.auth = {};
-  result.database.auth.user = authUser;
-  result.database.auth.pass = authPassword;
-  result.database.auth.source = databaseName;
-  result.database.name = databaseName;
-
-  assert.ok(authUser != undefined);
-  assert.ok(authPassword != undefined);
-  assert.ok(databaseName != undefined);
-
-  //Parsing options
-  if (options) {
-    var parsedOptions = options.split(",");
-    //If options are parsed, they should have an even number of elements in the split array
-    assert.ok(parsedOptions.length > 0);
-
-    for (var i = 0; i < parsedOptions.length; i++) {
-      var splitOption = parsedOptions[i].split("=");
-      //Each option should be something=value
-      assert.ok(splitOption && splitOption.length == 2);
-      assert.ok(splitOption[0].length > 0);
-      assert.ok(splitOption[1].length > 0);
-      //Checking it does not already exist
-      assert.ok(!result.database.driver_options[splitOption[0]]);
-
-      result.database.driver_options[splitOption[0]] = splitOption[1];
-    }
-  }
-
-  if (hostList.length > 1) {
-    result.database.host = [];
-    result.database.port = [];
-    for (i = 0; i < hostList.length; i++) {
-      var host_port = hostList[i].split(":");
-      assert.ok(host_port[0] && host_port[0].length > 0);
-      result.database.host.push(host_port[0]);
-      if (host_port.length > 1) {
-        result.database.port.push(host_port[1]);
-      } else {
-        result.database.port.push('27017');
-      }
-    }
-  }
-  else {
-    var host_port = hostList[0].split(":");
-    assert.ok(host_port[0] && host_port[0].length > 0);
-    result.database.host = host_port[0];
-    if (host_port.length > 1) {
-      result.database.port = host_port[1];
-    } else {
-      result.database.port = '27017';
-    }
-  }
-
-
-  //Verify the config to be returned
-  assert.ok(result.database.name.length > 0);
-  assert.ok(result.database.auth.user.length > 0);
-  assert.ok(result.database.auth.pass.length > 0);
-
-
-  return result;
-}
-
 
 function getDitchHandle(cb) {
 
@@ -129,7 +34,6 @@ function getDitchHandle(cb) {
       my_db_logger.error(errMessage);
       return cb(errMessage);
     }
-
   }
 
   if (!ditch) {
@@ -151,7 +55,7 @@ var tearDownDitch = function () {
   if (ditch)
     ditch.tearDown();
   ditch = null;
-}
+};
 
 var local_db = function (params, cb) {
   var action = params.act;
@@ -228,31 +132,29 @@ var local_db = function (params, cb) {
   });
 };
 
-var logCfg = {
-  error: true,
-  warn: false,
-  warning: false,
-  info: false,
-  debug: false
-};
-
-var my_db_logger = {
-  error: function (s) {doLog("error", "LOCALDB error", s);},
-  warn: function (s) {doLog("warn", "LOCALDB warn", s);},
-  warning: function (s) {doLog("warning", "LOCALDB warning", s);},
-  info: function (s) {doLog("info", "LOCALDB info", s);},
-  debug: function (s) {doLog("debug", "LOCALDB debug", s);}
-};
-
-var doLog = function(level, prefix, msg) {
-  if( logCfg[level] ) {
-    console.log(prefix, msg);
-  }
-}
-
 exports.local_db = local_db;
 exports.tearDownDitch = tearDownDitch;
 exports.Ditcher = fhditcher.Ditcher;
 exports.Database = fhdb.Database;
 exports.parseMongoConnectionURL = parseMongoConnectionURL;
 exports.permission_map = permission_map;
+
+/**
+ * Node.js MongoDB 2.0 driver compatible API that works with shared and
+ * dedicated databases. Returns either a wrapper API instance around
+ * ditcher or a MongoDB connection handle.
+ *
+ * Example usage:
+ *
+ * var localdb = require('fh-db');
+ * localdb.createMongoCompatApi({
+ *   __fhdb: <CURRENT FH-DB>,
+ *   __dbperapp: <TRUE|FALSE>,
+ *   connectionUrl: <MONGODB CONNECTION URL>
+ * }).then(function (api) {
+ *  api.collection("users").find(...);
+ * }).catch(function (err) {
+ *   logger.error({err: err}, "Api could not be created");
+ * });
+ */
+exports.createMongoCompatApi = require("./mongo_compat_api");

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,0 +1,27 @@
+// Dummy logger
+// Should be replaced with a real logger if fh-db is beeing used in the
+// future.
+
+var logCfg = {
+  error: true,
+  warn: false,
+  warning: false,
+  info: false,
+  debug: false
+};
+
+var logger = console;
+
+var doLog = function(level, prefix, msg) {
+  if( logCfg[level] ) {
+    logger.log(prefix, msg);
+  }
+};
+
+module.exports = {
+  error: function (s) {doLog("error", "LOCALDB error", s);},
+  warn: function (s) {doLog("warn", "LOCALDB warn", s);},
+  warning: function (s) {doLog("warning", "LOCALDB warning", s);},
+  info: function (s) {doLog("info", "LOCALDB info", s);},
+  debug: function (s) {doLog("debug", "LOCALDB debug", s);}
+};

--- a/lib/mongo_compat_api.js
+++ b/lib/mongo_compat_api.js
@@ -1,0 +1,292 @@
+var Promise = require("bluebird");
+var assert = require("assert");
+var fhditcher = require("./ditcher");
+var logger = require("./logger");
+var utils = require("./utils");
+var MongoClient = require("mongodb").MongoClient;
+
+/**
+ * Create a ditcher instance in case we are working with a shared
+ * database.
+ *
+ * @param mongoUrl Mongodb connection string to be used
+ * @param callback result callback
+ */
+function createDitcherInstance(mongoUrl, callback) {
+  // Default config used by ditcher if no connection string
+  // is provided
+  var config = {
+    database: {
+      host: '127.0.0.1',
+      port: process.env.FH_LOCAL_DB_PORT || 27017,
+      name: 'FH_LOCAL'
+    }
+  };
+
+  if (mongoUrl) {
+    try {
+      config = utils.parseMongoConnectionURL(mongoUrl);
+    } catch(e) {
+      return callback(e);
+    }
+  }
+
+  var versString = (mongoUrl) ? "db per app" : "shared db";
+  var ditcher = new fhditcher.Ditcher(config, logger, versString, function () {
+    return callback(null, ditcher);
+  });
+}
+
+/**
+ * Implements a MongoDB Node.js 2.0 driver compatible API that works for
+ * both, shared and dedicated database.
+ *
+ * @param ditcher ditcher instance
+ * @param params default params for the current app
+ * @constructor
+ */
+var MongoCompatApi = function (params) {
+  assert.ok(params.__fhdb, "__fhdb parameter required for shared database");
+
+  /**
+   * Copy the default options that are always required by ditcher
+   * @param target The options object to copy them to
+   * @returns The options object plus the default properties
+   */
+  this.copyDefaultOptions = function (target) {
+    target.__fhdb = params.__fhdb;
+    target.__dbperapp = params.__dbperapp;
+    return target;
+  };
+
+  /**
+   * Create a new collection
+   * http://mongodb.github.io/node-mongodb-native/2.0/api/Db.html#createCollection
+   * @param name collection name
+   * @param (optional) options
+   * @param (optional) callback results callback
+   * @returns Promise if no callback passed
+   */
+  this.createCollection = function (name, options, callback) {
+    assert.ok(name, "collection name required");
+
+    if (typeof options === "function") {
+      callback = options;
+      options = {};
+    }
+
+    options = this.copyDefaultOptions(options || {});
+    options.type = name;
+
+    if (callback) {
+      params.ditcher.doCreate(options, callback);
+    } else {
+      return new Promise(function (resolve, reject) {
+        params.ditcher.doCreate(options, function (err, collection) {
+          if (err) {
+            return reject(err);
+          }
+
+          resolve(collection);
+        });
+      });
+    }
+  };
+
+  /**
+   * Drop a collection
+   * http://mongodb.github.io/node-mongodb-native/2.0/api/Db.html#dropCollection
+   * @param name
+   * @param (optional) callback
+   * @returns Promise if no callback passed
+   */
+  this.dropCollection = function (name, callback) {
+    assert.ok(name, "collection name required");
+
+    var options = {
+      type: name
+    };
+
+    options = this.copyDefaultOptions(options || {});
+
+    if (callback) {
+      params.ditcher.doDropCollection(options, callback);
+    } else {
+      return new Promise(function (resolve, reject) {
+        params.ditcher.doDropCollection(options, function (err, result) {
+          if (err) {
+            return reject(err);
+          }
+
+          resolve(result);
+        });
+      });
+    }
+  };
+
+  /**
+   * List all collections
+   * http://mongodb.github.io/node-mongodb-native/2.0/api/Db.html#listCollections
+   * @param filter Query to filter collections by
+   * @param options (optional) Optional settings
+   * @returns Cursor
+   */
+  this.listCollections = function (filter, options) {
+    options = this.copyDefaultOptions(options || {});
+    return params.ditcher.doGetCollectionsListCursor(filter, options);
+  };
+
+  /**
+   * Return collections instance
+   * http://mongodb.github.io/node-mongodb-native/2.0/api/Db.html#collection
+   * @param name Query to filter collections by
+   * @param options (optional) Optional settings
+   * @param callback (optional) result callback
+   * @returns Collection instance if no callback passed
+   */
+  this.collection = function (name, options, callback) {
+    assert.ok(name, "collection name required");
+
+    options = this.copyDefaultOptions(options || {});
+    options.type = name;
+
+    return params.ditcher.doGetCollectionInstance(options, callback);
+  };
+
+  /**
+   * Create an index on collection
+   * http://mongodb.github.io/node-mongodb-native/2.0/api/Db.html#createIndex
+   * @param name Name of the collection
+   * @param fieldOrSpec Field to use for the index
+   * @param options (optional) Options
+   * @param callback (optional) result callback
+   * @returns Promise if no callback passed
+   */
+  this.createIndex = function (name, fieldOrSpec, options, callback) {
+    assert.ok(name, "collection name required");
+    assert.ok(fieldOrSpec, "index spec required");
+
+    if(typeof options === "function") {
+      callback = options;
+      options = {};
+    }
+
+    options = this.copyDefaultOptions(options || {});
+    options.type = name;
+    options.index = fieldOrSpec;
+
+    if (callback) {
+      params.ditcher.doIndex(options, callback);
+    } else {
+      return new Promise(function (resolve, reject) {
+        params.ditcher.doIndex(options, function (err, result) {
+          if (err) {
+            return reject(err);
+          }
+
+          resolve(result);
+        });
+      });
+    }
+  };
+
+  /**
+   * Rename a collection
+   * http://mongodb.github.io/node-mongodb-native/2.0/api/Db.html#renameCollection
+   * @param fromCollection Current name
+   * @param toCollection New name
+   * @param options (optional) Options
+   * @param callback (optional) Result callback
+   */
+  this.renameCollection = function (fromCollection, toCollection, options, callback) {
+    assert.ok(fromCollection, "current collection name required");
+    assert.ok(toCollection, "new collection name required");
+
+    if(typeof options === "function") {
+      callback = options;
+      options = {};
+    }
+
+    options = this.copyDefaultOptions(options || {});
+    options.type = fromCollection;
+    options.toCollection = toCollection;
+
+    if (callback) {
+      params.ditcher.doRenameCollection(options, callback);
+    } else {
+      return new Promise(function (resolve, reject) {
+        params.ditcher.doRenameCollection(options, function (err, result) {
+          if (err) {
+            return reject(err);
+          }
+
+          resolve(result);
+        });
+      });
+    }
+  };
+
+  /**
+   * Close the database connection
+   * http://mongodb.github.io/node-mongodb-native/2.0/api/Db.html#close
+   * @param force Force close, emitting no events
+   * @param callback (optional) result callback
+   */
+  this.close = function (force, callback) {
+    if (typeof force === "function") {
+      callback = force;
+      force = false;
+    }
+
+    return params.ditcher.database.close(force, callback);
+  };
+};
+
+/**
+ * The constructor function. Returns either an instance of the wrapper API
+ * around ditcher or a MongoDB handle as a promise.
+ *
+ * @param params required and optional parameters. The following parameters are accepted:
+ *        __dbperapp:       (required) decides if shared or dedicated database is used and determines
+ *                          if an wrapper API instance of a native MongoDB connection is returned
+ *        __fhdb:           (optional) Passed by fh-mbaas-api. The name of the MongoDB database to use
+ *                          for a given app in shared mode
+ *        connectionUrl:    (optional) MongoDB connection URL. Will be used in shared or dedicated mode. If no URL is
+ *                          passed an attempt to connec to `localhost` on the default port will be made.
+ *        options:          (optional) Connection options, used for native mongo connections
+ * @returns Promise
+ */
+module.exports = function (params) {
+  assert.ok(typeof params.__dbperapp !== "undefined", "__dbperapp parameter required");
+
+  if (params.__dbperapp) {
+    var options = params.options || {};
+    // DB per app: each app has its own database. Create a direct connection to
+    // this database and return the mongo handle
+    return new Promise(function (resolve, reject) {
+      MongoClient.connect(params.connectionUrl, options, function (err, db) {
+        if (err) {
+          return reject(err);
+        }
+
+        // Return the real thing
+        return resolve(db);
+      });
+    });
+  } else {
+    // Shared DB: create ditcher instance and use it to access the collections
+    // in the shared database. `params#connectionUrl` points to the shared database
+    return new Promise(function (resolve, reject) {
+      createDitcherInstance(params.connectionUrl, function (err, ditcher) {
+        if (err) {
+          return reject(err);
+        }
+
+        params.ditcher = ditcher;
+
+        // Return an instance of the wrapper API around ditcher
+        return resolve(new MongoCompatApi(params));
+      });
+    });
+  }
+};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,193 @@
+var assert = require("assert");
+
+/**
+ * Parse a MongodB connection URL, split it up and return an object
+ * containing the configuration properties.
+ * @param mongoConnectionURL The connection URL as String
+ * @returns Configuration Object
+ */
+exports.parseMongoConnectionURL = function (mongoConnectionURL) {
+  var result = {};
+
+  //The connection string will be of the form mongodb://user:password@host:port,host2port2/databasename?option=someOption
+  //String to break down the mongodb url into a ditch config hash
+  var auth_hosts_path_options = new Buffer(mongoConnectionURL).toString().split("//")[1];
+
+  //user:password , host:port,host2:port2/databasename?option=someOption
+  var auth = auth_hosts_path_options.split("@")[0];
+
+
+  var hosts_path_options = auth_hosts_path_options.split("@")[1];
+
+  // host:port,host2:port2/databasename , option=someOption
+  var hosts_path = hosts_path_options.split("?")[0];
+  var options = hosts_path_options.split("?")[1];
+
+  //host:port,host2:port2, databasename
+  var hosts = hosts_path.split("/")[0];
+  var databaseName = hosts_path.split("/")[1];
+
+  //host:port host2:port2
+  var hostList = hosts.split(",");
+
+  //user, password
+  var authUser = auth.split(":")[0];
+  var authPassword = auth.split(":")[1];
+
+  result.database = {};
+  result.database.driver_options = {};
+  result.database.auth = {};
+  result.database.auth.user = authUser;
+  result.database.auth.pass = authPassword;
+  result.database.auth.source = databaseName;
+  result.database.name = databaseName;
+
+  assert.ok(authUser !== undefined);
+  assert.ok(authPassword !== undefined);
+  assert.ok(databaseName !== undefined);
+
+  //Parsing options
+  if (options) {
+    var parsedOptions = options.split(",");
+    //If options are parsed, they should have an even number of elements in the split array
+    assert.ok(parsedOptions.length > 0);
+
+    for (var i = 0; i < parsedOptions.length; i++) {
+      var splitOption = parsedOptions[i].split("=");
+      //Each option should be something=value
+      assert.ok(splitOption && splitOption.length === 2);
+      assert.ok(splitOption[0].length > 0);
+      assert.ok(splitOption[1].length > 0);
+      //Checking it does not already exist
+      assert.ok(!result.database.driver_options[splitOption[0]]);
+
+      result.database.driver_options[splitOption[0]] = splitOption[1];
+    }
+  }
+
+  var host_port;
+  if (hostList.length > 1) {
+    result.database.host = [];
+    result.database.port = [];
+    for (i = 0; i < hostList.length; i++) {
+      host_port = hostList[i].split(":");
+      assert.ok(host_port[0] && host_port[0].length > 0);
+      result.database.host.push(host_port[0]);
+      if (host_port.length > 1) {
+        result.database.port.push(host_port[1]);
+      } else {
+        result.database.port.push('27017');
+      }
+    }
+  }
+  else {
+    host_port = hostList[0].split(":");
+    assert.ok(host_port[0] && host_port[0].length > 0);
+    result.database.host = host_port[0];
+    if (host_port.length > 1) {
+      result.database.port = host_port[1];
+    } else {
+      result.database.port = '27017';
+    }
+  }
+
+
+  //Verify the config to be returned
+  assert.ok(result.database.name.length > 0);
+  assert.ok(result.database.auth.user.length > 0);
+  assert.ok(result.database.auth.pass.length > 0);
+
+
+  return result;
+};
+
+/**
+ * This will return a connection URL like:
+ * host1[:port1][,host2[:port2],...[,hostN[:portN]]]
+ *
+ * With the intention that it can be prepended with "mongodb://[username]:[password]@"
+ * and appended with "/[database][?options]
+ *
+ * @param host This is expected in the format: "host1" or "host1,host2" or ["host1", "host2"]
+ * @param port This is expected in the format: 123 or "123" or "123,456" or ["123", "456"] or [123, 456]
+ *
+ * @returns {string} host1[:port1][,host2[:port2],...[,hostN[:portN]]]
+ */
+exports.parseConnectionUrl = function (host, port){
+  var hosts = [];
+  var ports = [];
+
+  //normalise host to an array
+  if(! host) {
+    hosts  = ['localhost'];
+  } else if('string' === typeof host && host.split(',').length <= 1){
+    hosts = [host];
+  } else if ('string' === typeof host && host.split(',').length > 1){
+    hosts = host.split(',');
+  } else if (Array.isArray(host)){
+    hosts = host;
+  }
+
+  //normalise port to an array
+  if(! port){
+    ports = [27017];
+  } else if('string' === typeof port && port.split(',').length <= 1 || 'number' === typeof port){
+    ports = [port];
+  } else if ('string' === typeof port && port.split(',').length > 1){
+    ports = port.split(',');
+  } else if (Array.isArray(port)){
+    ports = port;
+  }
+
+  var connectionHosts = [];
+
+  for( var hostIndex=0; hostIndex < hosts.length; hostIndex++ ){
+    connectionHosts[hostIndex] = hosts[hostIndex];
+
+    //if only one port specified, use it on all hosts, otherwise assume number of ports and hosts are equal
+    if(ports.length === 1){
+      connectionHosts[hostIndex] += ":" + ports[0];
+    } else {
+      connectionHosts[hostIndex] += ":" + ports[hostIndex];
+    }
+  }
+
+  return connectionHosts.join(',');
+};
+
+
+/**
+ * Returns the driver options URL encoded for the connection string; e.g.: w=1&j=true
+ *
+ * @param options an Array of options
+ *
+ * @returns {string}
+ */
+exports.parseConnectionUrlOptions = function (options) {
+  //set default values
+  var retOptions = { w: 1, j: true, numberOfRetries: 5, retryMiliSeconds: 2000, native_parser:false};
+
+  //override defaults
+  if (options) {
+    for (var field in options) {
+      // RHMAP-9817 if a field (more explicitly replicaSet) is empty don't include it in the options
+      // The reason that the comparator to an empty string was used is that the options[field] value can be set to false
+      // and hence not get included
+      if (options[field] !== "") {
+        retOptions[field] = options[field];
+      }
+    }
+  }
+  var argParts = [];
+
+  //convert options to arg string
+  for(var opt in retOptions) {
+    if (retOptions.hasOwnProperty(opt)) {
+      argParts.push(encodeURIComponent(opt) + "=" + encodeURIComponent(retOptions[opt]));
+    }
+  }
+  if(argParts.length) {
+    return "?" + argParts.join("&");
+  }
+  return "";
+};

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-db",
-  "version": "1.2.5",
+  "version": "1.3.1",
   "dependencies": {
     "adm-zip": {
       "version": "0.4.7",
@@ -13,14 +13,14 @@
       "resolved": "https://registry.npmjs.org/archiver/-/archiver-1.0.0.tgz",
       "dependencies": {
         "archiver-utils": {
-          "version": "1.2.0",
+          "version": "1.3.0",
           "from": "archiver-utils@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.3.0.tgz",
           "dependencies": {
             "graceful-fs": {
-              "version": "4.1.6",
+              "version": "4.1.11",
               "from": "graceful-fs@>=4.1.0 <5.0.0",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.6.tgz"
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
             },
             "lazystream": {
               "version": "1.0.0",
@@ -35,14 +35,14 @@
           }
         },
         "buffer-crc32": {
-          "version": "0.2.5",
+          "version": "0.2.13",
           "from": "buffer-crc32@>=0.2.1 <0.3.0",
-          "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.5.tgz"
+          "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz"
         },
         "glob": {
-          "version": "7.0.6",
+          "version": "7.1.1",
           "from": "glob@>=7.0.0 <8.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
           "dependencies": {
             "fs.realpath": {
               "version": "1.0.0",
@@ -50,9 +50,9 @@
               "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
             },
             "inflight": {
-              "version": "1.0.5",
+              "version": "1.0.6",
               "from": "inflight@>=1.0.4 <2.0.0",
-              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.2",
@@ -62,9 +62,9 @@
               }
             },
             "inherits": {
-              "version": "2.0.1",
-              "from": "inherits@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+              "version": "2.0.3",
+              "from": "inherits@>=2.0.1 <2.1.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
             },
             "minimatch": {
               "version": "3.0.3",
@@ -91,9 +91,9 @@
               }
             },
             "once": {
-              "version": "1.3.3",
+              "version": "1.4.0",
               "from": "once@>=1.3.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.2",
@@ -103,21 +103,21 @@
               }
             },
             "path-is-absolute": {
-              "version": "1.0.0",
+              "version": "1.0.1",
               "from": "path-is-absolute@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
             }
           }
         },
         "lodash": {
-          "version": "4.15.0",
+          "version": "4.17.2",
           "from": "lodash@>=4.8.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz"
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
         },
         "readable-stream": {
-          "version": "2.1.5",
+          "version": "2.2.2",
           "from": "readable-stream@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
           "dependencies": {
             "buffer-shims": {
               "version": "1.0.0",
@@ -129,15 +129,15 @@
               "from": "core-util-is@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
             },
-            "inherits": {
-              "version": "2.0.1",
-              "from": "inherits@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-            },
             "isarray": {
               "version": "1.0.0",
               "from": "isarray@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "from": "inherits@>=2.0.1 <2.1.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
             },
             "process-nextick-args": {
               "version": "1.0.7",
@@ -177,9 +177,9 @@
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "inherits": {
-                      "version": "2.0.1",
+                      "version": "2.0.3",
                       "from": "inherits@>=2.0.1 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                     },
                     "isarray": {
                       "version": "1.0.0",
@@ -212,7 +212,7 @@
               "dependencies": {
                 "once": {
                   "version": "1.3.3",
-                  "from": "once@>=1.3.0 <2.0.0",
+                  "from": "once@>=1.3.0 <1.4.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                   "dependencies": {
                     "wrappy": {
@@ -232,24 +232,19 @@
           }
         },
         "zip-stream": {
-          "version": "1.0.0",
+          "version": "1.1.0",
           "from": "zip-stream@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.1.0.tgz",
           "dependencies": {
             "compress-commons": {
-              "version": "1.0.0",
-              "from": "compress-commons@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.0.0.tgz",
+              "version": "1.1.0",
+              "from": "compress-commons@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.1.0.tgz",
               "dependencies": {
                 "crc32-stream": {
                   "version": "1.0.0",
                   "from": "crc32-stream@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-1.0.0.tgz"
-                },
-                "node-int64": {
-                  "version": "0.4.0",
-                  "from": "node-int64@>=0.4.0 <0.5.0",
-                  "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz"
                 },
                 "normalize-path": {
                   "version": "2.0.1",
@@ -266,6 +261,11 @@
       "version": "1.5.2",
       "from": "async@1.5.2",
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+    },
+    "bluebird": {
+      "version": "3.4.6",
+      "from": "bluebird@>=3.4.6 <4.0.0",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.6.tgz"
     },
     "bson": {
       "version": "0.4.22",
@@ -347,9 +347,9 @@
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
             },
             "inherits": {
-              "version": "2.0.1",
-              "from": "inherits@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+              "version": "2.0.3",
+              "from": "inherits@>=2.0.1 <2.1.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
             }
           }
         }

--- a/package.json
+++ b/package.json
@@ -22,17 +22,18 @@
     "adm-zip": "~0.4.4",
     "archiver": "1.0.0",
     "async": "1.5.2",
+    "bluebird": "^3.4.6",
     "bson": "0.4.22",
     "csvtojson": "0.3.6",
     "jcsv": "0.0.3",
     "lodash": "2.4.1",
     "mongodb": "2.1.18",
     "stream-buffers": "3.0.0"
-
   },
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-fh-build": "^0.5.0",
-    "istanbul": "^0.3.17"
+    "istanbul": "^0.3.17",
+    "mocha": "^3.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-db",
   "description": "FeedHenry Database Library",
-  "version": "1.2.5",
+  "version": "1.3.1",
   "repository": {
     "type": "git",
     "url": "git@github.com:feedhenry/fh-db.git"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-db
 sonar.projectName=fh-db-nightly-master
-sonar.projectVersion=1.2.5
+sonar.projectVersion=1.3.1
 
 sonar.sources=./lib
 sonar.tests=./test

--- a/test/fixtures/base_config.json
+++ b/test/fixtures/base_config.json
@@ -1,0 +1,26 @@
+{
+  "database" : {
+    "host" : "localhost",
+    "port" : 27017,
+    "name" : "fh_ditch_test",
+    "adminauth" : {
+      "user": "admin",
+      "pass": "admin"
+    },
+    "auth" : {
+      "user": "ditchuser",
+      "pass": "ditchpassword",
+      "source": "fh-ditch"
+    },
+    "driver_options": {"w":1, "j":1}
+  },
+
+  "logger" : {
+    "loglevel" : 3
+  },
+  "fhamqpjs": {
+    "enabled": true,
+    "clusterNodes": ["amqp://localhost:5672"],
+    "maxReconnectAttempts": 10
+  }
+}

--- a/test/fixtures/dummy_logger.js
+++ b/test/fixtures/dummy_logger.js
@@ -1,0 +1,11 @@
+// Used as the log object in tests where no real output is desired
+var logFn = function () {};
+
+module.exports = {
+  silly: logFn,
+  trace: logFn,
+  debug: logFn,
+  info: logFn,
+  warn: logFn,
+  error: logFn
+};

--- a/test/mocha/mocha_tst_mongo_compat_api.js
+++ b/test/mocha/mocha_tst_mongo_compat_api.js
@@ -1,0 +1,215 @@
+var createApi = require("../../lib/mongo_compat_api");
+var fhmongodb = require("../../lib/fhmongodb");
+var mongodb = require('mongodb');
+var Server = mongodb.Server;
+var assert = require('assert');
+var config = require("./../fixtures/base_config.json");
+
+var DB_PER_APP = process.env.DB_PER_APP === "true";
+
+var TEST_DB_NAME = "testDB-123412341234123412341234-API";
+var TEST_COL_NAME = "test_mongo_compat_api_col";
+
+config.database.name = TEST_DB_NAME;
+
+var api = null;
+var db = null;
+
+function createDatabasesAndUsers(cfg, callback){
+  var db = new mongodb.Db(cfg.database.name, new Server(cfg.database.host, cfg.database.port), {fsync:true});
+
+  db.open(function(err, targetDb){
+    if(err) return callback(err);
+
+    targetDb.authenticate(cfg.database.adminauth.user, cfg.database.adminauth.pass, {authSource:"admin"}, function(err, result){
+      if(err)
+        return callback(err);
+
+      targetDb.dropDatabase(function(err, result) {
+        if(err) return callback(err);
+
+        targetDb.removeUser(cfg.database.auth.user, function(){
+          targetDb.addUser(cfg.database.auth.user, cfg.database.auth.pass, function(err, result){
+            if(err) return callback(err);
+
+            //Database created and user added. The rest of the tests will work as normal.
+            targetDb.close();
+            callback();
+          });
+        });
+      });
+    });
+  });
+}
+
+before(function (done) {
+  createDatabasesAndUsers(config, function () {
+    createApi({
+      __fhdb: TEST_DB_NAME,
+      __dbperapp: DB_PER_APP,
+      connectionUrl: DB_PER_APP ? "mongodb://localhost:27017" : undefined
+    }).then(function (apiInstance) {
+      api = apiInstance;
+      done();
+    });
+  });
+});
+
+after(function (done) {
+  api.close().then(function () {
+    done();
+  }).catch(function () {
+    throw new Error("Error closing the database connection");
+  });
+});
+
+describe("MongoDB Node.js driver 2.0 compatible API (db per app: " + DB_PER_APP + ")", function () {
+  it("creates collection using callback", function (done) {
+    // The `fields` object must be passed when the API is used with a shared
+    // database. Otherwise the collection will not be created.
+    api.createCollection(TEST_COL_NAME, {
+      "fields": {
+        "firstName" : "Joe",
+        "lastName" : "Bloggs"
+      }
+    }, function (err, collection) {
+      assert.ifError(err);
+      assert.ok(collection, "Collection has not been created");
+      done();
+    });
+  });
+
+  it("drops collection using callback", function (done) {
+    api.dropCollection(TEST_COL_NAME, function (err, result) {
+      assert.ifError(err);
+      assert.ok(result);
+      done();
+    });
+  });
+
+  it("creates collection using promise", function (done) {
+    api.createCollection(TEST_COL_NAME, {
+      "fields": {
+        "firstName" : "Joe",
+        "lastName" : "Bloggs"
+      }
+    }).then(function (collection) {
+      assert.ok(collection, "Collection has not been created");
+      done();
+    }).catch(function (err) {
+      throw new Error("Collection not created");
+    });
+  });
+
+  it("drops collection using promise", function (done) {
+    api.dropCollection(TEST_COL_NAME).then(function (result) {
+      assert.ok(result);
+      done();
+    }).catch(function () {
+      throw new Error("Collection not dropped");
+    });
+  });
+
+  it("lists collections using cursor", function (done) {
+    api.createCollection(TEST_COL_NAME, {
+      "fields": {
+        "firstName" : "Joe",
+        "lastName" : "Bloggs"
+      }
+    }, function (err, collection) {
+      assert.ifError(err);
+      assert.ok(collection, "Collection has not been created");
+      var cursor = api.listCollections();
+      assert.ok(cursor, "No cursor returned");
+      cursor.toArray(function (error, documents) {
+        assert.ifError(error);
+        for (var i = 0; i < documents.length; i++) {
+          if (documents[i].name.indexOf(TEST_COL_NAME) >= 0) {
+            return done();
+          }
+        }
+        throw new Error("Collection not returned in `#listCollections`")
+      });
+    });
+  });
+
+  it("returns collection instance", function (done) {
+    var col = api.collection(TEST_COL_NAME);
+    assert.ok(col, "No collection returned");
+    done();
+  });
+
+  it("returns collection with callback", function (done) {
+    api.collection(TEST_COL_NAME, function (err, collection) {
+      assert.ifError(err);
+      assert.ok(collection, "No collection returned");
+      done();
+    });
+  });
+
+  it("creates index with callback", function (done) {
+    api.createIndex(TEST_COL_NAME, "firstName", function (err, result) {
+      assert.ifError(err);
+      assert.ok(result, "Index not created");
+      done();
+    });
+  });
+
+  it("creates index with promise", function (done) {
+    api.createIndex(TEST_COL_NAME, "firstName").then(function (result) {
+      assert.ok(result, "Index not created");
+      done();
+    }).catch(function () {
+      throw new Error("index not created");
+    });
+  });
+
+  it("inserts document with callback", function (done) {
+    api.collection(TEST_COL_NAME).insert({
+      firstName: "dummy-callback",
+      lastName: "user"
+    }, function (err, result) {
+      assert.ifError(err);
+      assert.equal(result.insertedCount, 1, "No documents inserted");
+      done();
+    });
+  });
+
+  it("inserts document with promises", function (done) {
+    api.collection(TEST_COL_NAME).insert({
+      firstName: "dummy-promise",
+      lastName: "user"
+    }).then(function (result) {
+      assert.equal(result.insertedCount, 1, "No documents inserted");
+      done();
+    }).catch(function () {
+      throw new Error("No documents inserted")
+    })
+  });
+
+  it("find document returning cursor", function (done) {
+    api.collection(TEST_COL_NAME).find({"firstName": "dummy-callback"}).toArray(function (err, docs) {
+      assert.ifError(err);
+      assert.ok(docs);
+      assert.equal(docs.length, 1);
+      done();
+    });
+  });
+
+  it("renames collection using callback", function (done) {
+    api.renameCollection(TEST_COL_NAME, TEST_COL_NAME + "_2", function (err, collection) {
+      assert.ifError(err);
+      assert.ok(collection);
+      done();
+    });
+  });
+
+  it("renames collection using promise", function (done) {
+    api.renameCollection(TEST_COL_NAME + "_2", TEST_COL_NAME).then(function (collection) {
+      assert.ok(collection);
+      done();
+    }).catch(function () {
+      throw new Error("Collection not renamed");
+    });
+  });
+});

--- a/test/test_ditcher.js
+++ b/test/test_ditcher.js
@@ -39,33 +39,7 @@ var importExportHelpers = require('../lib/importexport/helpers.js')(logger);
 
 var ditch;
 
-
-var config = {
-  "database" : {
-    "host" : "localhost",
-    "port" : 27017,
-    "name" : "fh_ditch_test",
-    "adminauth" : {
-          "user": "admin",
-          "pass": "admin"
-        },
-    "auth" : {
-      "user": "ditchuser",
-      "pass": "ditchpassword",
-      "source": "fh-ditch"
-    },
-    "driver_options": {w:1, j:1}
-  },
-
-  "logger" : {
-    "loglevel" : 3
-  },
-  "fhamqpjs": {
-      "enabled": true,
-      "clusterNodes": ["amqp://localhost:5672"],
-      "maxReconnectAttempts": 10
-    }
-};
+var config = require("./fixtures/base_config.json");
 
 var own_app_config = {
   "database" : {


### PR DESCRIPTION
# Motivation

Extends the fh-db API with a MongoDB compatible layer on top of shared and dedicated databases. This API can be consumed by the new backend service for the databrowser and provides easy replaceability with the actual MongoDB driver as soon as we don't have to support shared dbs.

The API supports the exact MongoDB driver semantics, including promises and cursors. Naming conventions for shared dbs are adhered in all API calls. The following functions are implemented:

```
#createCollection
#dropCollection
#listCollections
#collection
#createIndex
#renameCollection
#close
``` 

Advanced API for CRUD operations can be easily used for shared and dedicated dbs by using the `collection` function and running queries on collections:

```javascript
var localdb = require('fh-db');
localdb.createMongoCompatApi({
  __dbperapp: <true|false>,
  __fhdb: <passed by fh-mbaas-api, only required for shared db>,
  connectionUrl: <connection url for shared or dedicated database>
}).then(function (db) {
  // db is now either a native mongodb connection or a compatible wrapper API
  db.collection("user").find(...);
});

```

ping @wei-lee @rachael-oregan @sedroche 