### PR TITLE
Allow getDitcher act to be called

### DIFF
--- a/lib/localdb.js
+++ b/lib/localdb.js
@@ -68,7 +68,9 @@ var local_db = function (params, cb) {
 
     // Using the `name` property from the permission map here to make
     // sure this one gets updated as new actions are added.
-    if (permission_map.db.create.name === action) {
+    if ('getDitcher' === action) {
+      return cb(null, ditch);
+    } else if (permission_map.db.create.name === action) {
       my_db_logger.debug('about to: create');
       ditch.doCreate(params, function (err, id) {
         my_db_logger.debug('back from create: err', err, "id:", id);
@@ -126,7 +128,7 @@ var local_db = function (params, cb) {
     } else if (permission_map.db.close.name === action) {
       tearDownDitch();
       return cb();
-    }else {
+    } else {
       return cb(new Error("Unknown fh.db action"));
     }
   });

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-db",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "dependencies": {
     "adm-zip": {
       "version": "0.4.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-db",
   "description": "FeedHenry Database Library",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "repository": {
     "type": "git",
     "url": "git@github.com:feedhenry/fh-db.git"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-db
 sonar.projectName=fh-db-nightly-master
-sonar.projectVersion=1.4.0
+sonar.projectVersion=1.4.1
 
 sonar.sources=./lib
 sonar.tests=./test


### PR DESCRIPTION
This is part of the change to expose the MongoDB client in fh-db to the
    user.

    This allows a new act to be called without a type, called getDitcher which
    will return the `ditcher.Ditcher` object created in the
    `localdb` module. This will then expose the `Database` object and the
    `mongo.Db` client within it.

    Further changes are required in `fh-mbaas-api`.