### PR TITLE
Rhmap 13226 - Can't import a previously exported empty json collection within the Studio's Data Browser

### DIFF
--- a/lib/ditcher.js
+++ b/lib/ditcher.js
@@ -591,13 +591,17 @@ Ditcher.prototype.doImport = function (params, cb) {
       return cb('No collections found to import');
     }
     var collectionsToImportArray = Object.keys(collectionsToImport);
+    var importedCollections = [];
 
-    collectionsToImportArray.forEach(function(colKey){
-      var name = constructCollectionName({ __fhdb : params.__fhdb, __dbperapp : params.__dbperapp, type : colKey}),
-      data = collectionsToImport[colKey];
-      importers[colKey] = function(callback){
-        self.database.create(name, data, callback);
-      };
+    collectionsToImportArray.forEach(function (colKey) {
+      if (collectionsToImport[colKey].length > 0) {
+        var name = constructCollectionName({ __fhdb: params.__fhdb, __dbperapp: params.__dbperapp, type: colKey }),
+          data = collectionsToImport[colKey];
+        importers[colKey] = function (callback) {
+          self.database.create(name, data, callback);
+        };
+        importedCollections.push(colKey);
+      }
     });
 
     return async.parallel(importers, function(err, res){
@@ -608,11 +612,11 @@ Ditcher.prototype.doImport = function (params, cb) {
       resSent = true;
       if (err){
         if (err.toString().indexOf("duplicate key error")>-1){
-          return cb({message : "You're importing duplicate data - please ensure your collections are empty before importing"});
+          return cb("You're importing duplicate data - please ensure your collections are empty before importing");
         }
-        return cb({message : err.toString()});
+        return cb(err.toString());
       }
-      return cb(null, {ok : true, imported : collectionsToImportArray});
+      return cb(null, { ok: true, imported: importedCollections});
 
     });
   });

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-db",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "dependencies": {
     "adm-zip": {
       "version": "0.4.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-db",
   "description": "FeedHenry Database Library",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "repository": {
     "type": "git",
     "url": "git@github.com:feedhenry/fh-db.git"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-db
 sonar.projectName=fh-db-nightly-master
-sonar.projectVersion=1.4.3
+sonar.projectVersion=1.4.4
 
 sonar.sources=./lib
 sonar.tests=./test


### PR DESCRIPTION
## Motivation
A previously exported zipped group of json collections from the Studio contained an empty json collection. Importing this .json collection within the Studio's Data Browser returns an unclear error message.

## Result
Return a message with a list of the collections that were successfully imported.

## Jira
https://issues.jboss.org/browse/RHMAP-13226