### PR TITLE
🐛 RHMAP-15177 Fix for running locally when using v7 of fh-mbaas-api

### DIFF
--- a/lib/localdb.js
+++ b/lib/localdb.js
@@ -18,7 +18,7 @@ function getDitchHandle(cb) {
     }
   };
 
-  if(process.env.FH_MONGODB_CONN_URL && ! process.env.FH_USE_LOCAL_DB ){
+  if(process.env.FH_MONGODB_CONN_URL){
     var mongoConnectionURL = process.env.FH_MONGODB_CONN_URL;
     my_db_logger.debug(mongoConnectionURL);
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-db",
   "description": "FeedHenry Database Library",
-  "version": "1.4.4",
+  "version": "2.0.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:feedhenry/fh-db.git"


### PR DESCRIPTION
The fh.sync API expects to be connecting directly to mongodb.
To support this, a change in fh-mbaas-api [1] sets FH_MONGODB_CONN_URL
appropriately if FH_USE_LOCAL_DB is set. Therefore, there should be
no special behaviour here in fh-db, and it should just use the
value of FH_MONGODB_CONN_URL

[1] https://github.com/feedhenry/fh-mbaas-api/pull/131