### PR TITLE
RHMAP-13690 - Unable to filter a collections documents by "_id" in DataBrowser

### DIFF
--- a/lib/convert_query_type.js
+++ b/lib/convert_query_type.js
@@ -1,0 +1,108 @@
+var ObjectId = require('mongodb').ObjectId;
+
+/**
+ * Creates an object containing the expression key and value queried.
+ *
+ * @param {String} expression - This is the operator used in query.
+ * @param {String} field - This is the column being quried.
+ * @param {ObjectId|Number|Boolean} value - This is the value being quried.
+ *
+ * @returns {Object} expressionQuery - contains the expressions key and query value.
+ */
+function query(value, field, expression) {
+    if (!expression) {
+        return value;
+    }
+
+    var expressionQuery = {};
+    expressionQuery[expression] = value;
+    return expressionQuery;
+};
+
+/**
+ * Tries to create a Number from the queried value.
+ *
+ * @param {String} value - This is the value being quried.
+ *
+ * @returns {Number}
+ */
+function number(value) {
+    var num = Number(value);
+    if (!Number.isNaN(num)) {
+        return num;
+    }
+};
+
+/**
+ * Tries to create an ObjectId from the queried value.
+ *
+ * @param {String} value - This is the value being quried.
+ *
+ * @returns {ObjectId}
+ */
+function objectId(value) {
+    try {
+        return ObjectId(value);
+    } catch (err) { };
+};
+
+/**
+ * Tries to create a Boolean from the queried value.
+ *
+ * @param {String} value - This is the value being quried.
+ *
+ * @returns {Boolean}
+ */
+function bool(value) {
+    if (value.toLowerCase() === 'true') {
+        return true;
+    } else if (value.toLowerCase() === 'false') {
+        return false;
+    }
+};
+
+// used to call parsing function for the "Any" type.
+var casters = [
+    number,
+    bool,
+    objectId
+];
+
+// contains functions to convert queries based on their type.
+var queryTypes = {
+    "Date": function (value, field, expression) {
+        return query(new Date(value), field, expression); // if a non date is input it will parse to a date anyway
+    },
+    "ObjectId": function (value, field, expression) {
+        return query(ObjectId(value), field, expression); // ngui will throw an error if this is not equal 24 char
+    },
+    "Any": function (value, field, expression) {
+        var compositeQuery = {};
+        compositeQuery[field] = query(value, field, expression);
+        var str = compositeQuery;
+        return casters.reduce(function (acc, caster) {
+            var val = caster(value);
+            if (typeof val !== "undefined") {
+                compositeQuery[field] = query(val, field, expression);
+                acc.push(compositeQuery);
+            }
+            return acc;
+        }, [str]);
+    }
+};
+
+/**
+ * Converts the query based on the type of query and if an expression was used
+ *
+ * @param {Object} type - Type will contain the type and value being queried. Type can have these values: "String", "Number", "Boolean", "Date", "ObjectId" or "Any".
+ * @param {String} field - This is the column being quried.
+ * @param {String} expression - This is the operator used in query e.g. "$ne" (not equal).
+ *
+ * @returns {String|Number|Boolean|Object}
+ */
+exports.queryType = function (type, field, expression) {
+    if (!queryTypes[type.type]) {
+        return query(type.value, field, expression);
+    }
+    return queryTypes[type.type](type.value, field, expression);
+};

--- a/lib/ditcher.js
+++ b/lib/ditcher.js
@@ -2,6 +2,7 @@ var fhdb = require('./fhmongodb.js');
 var EventEmitter = require('events').EventEmitter;
 var util = require("util");
 var async = require('async');
+var convert = require('./convert_query_type.js');
 var MAX_COLLECTION_NAME = 70;
 // If not single db per app, we need to be passed a valid AppName string, otherwise could be manipulating into listing anything
 var appname_regex = /.+-[a-zA-Z0-9]{24}-/;
@@ -49,9 +50,11 @@ var crit_ops = {
   eq: function (query, fields) {
     var field;
     if (null !== fields) {
-      for (field in  fields) {
-        if (fields.hasOwnProperty(field)) {
-          query[field] = fields[field];
+      for (field in fields) {
+        if (fields.hasOwnProperty(field) && fields[field].type === "Any") {
+          query['$or'] = convert.queryType(fields[field], field);
+        } else if (fields.hasOwnProperty(field)) {
+          query[field] = convert.queryType(fields[field], field);
         }
       }
     }
@@ -73,9 +76,6 @@ var crit_ops = {
   },
   like: function (query, fields) {
     buildQuery(query, fields, "$regex");
-  },
-  "in": function (query, fields) {
-    buildQuery(query, fields, "$in");
   },
   geo: function (query, fields) {
     if (null !== fields) {
@@ -104,13 +104,10 @@ function buildQuery(query, fields, expression) {
   var field;
   if (null !== fields) {
     for (field in  fields) {
-      if (fields.hasOwnProperty(field)) {
-        var queryField = {};
-        if ('undefined' !== typeof query[field]) {
-          queryField = query[field];
-        }
-        queryField[expression] = fields[field];
-        query[field] = queryField;
+      if (fields.hasOwnProperty(field) && fields[field].type === "Any") {
+        query['$or'] = convert.queryType(fields[field], field, expression);
+      } else if (fields.hasOwnProperty(field)) {
+        query[field] = convert.queryType(fields[field], field, expression);
       }
     }
   }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-db",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "dependencies": {
     "adm-zip": {
       "version": "0.4.7",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,37 +4,37 @@
   "dependencies": {
     "adm-zip": {
       "version": "0.4.7",
-      "from": "adm-zip@>=0.4.4 <0.5.0",
+      "from": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz",
       "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz"
     },
     "archiver": {
       "version": "1.0.0",
-      "from": "archiver@1.0.0",
+      "from": "https://registry.npmjs.org/archiver/-/archiver-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/archiver/-/archiver-1.0.0.tgz",
       "dependencies": {
         "archiver-utils": {
           "version": "1.3.0",
-          "from": "archiver-utils@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.3.0.tgz",
           "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.3.0.tgz",
           "dependencies": {
             "graceful-fs": {
               "version": "4.1.11",
-              "from": "graceful-fs@>=4.1.0 <5.0.0",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
             },
             "lazystream": {
               "version": "1.0.0",
-              "from": "lazystream@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz"
             },
             "normalize-path": {
               "version": "2.1.1",
-              "from": "normalize-path@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
               "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
               "dependencies": {
                 "remove-trailing-separator": {
                   "version": "1.0.1",
-                  "from": "remove-trailing-separator@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz"
                 }
               }
@@ -43,54 +43,54 @@
         },
         "buffer-crc32": {
           "version": "0.2.13",
-          "from": "buffer-crc32@>=0.2.1 <0.3.0",
+          "from": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
           "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz"
         },
         "glob": {
           "version": "7.1.1",
-          "from": "glob@>=7.0.0 <8.0.0",
+          "from": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
           "dependencies": {
             "fs.realpath": {
               "version": "1.0.0",
-              "from": "fs.realpath@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
             },
             "inflight": {
               "version": "1.0.6",
-              "from": "inflight@>=1.0.4 <2.0.0",
+              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.2",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                 }
               }
             },
             "inherits": {
               "version": "2.0.3",
-              "from": "inherits@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
             },
             "minimatch": {
               "version": "3.0.4",
-              "from": "minimatch@>=3.0.2 <4.0.0",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.7",
-                  "from": "brace-expansion@>=1.1.7 <2.0.0",
+                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.4.2",
-                      "from": "balanced-match@>=0.4.1 <0.5.0",
+                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
+                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
@@ -99,93 +99,93 @@
             },
             "once": {
               "version": "1.4.0",
-              "from": "once@>=1.3.0 <2.0.0",
+              "from": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
               "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.2",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                 }
               }
             },
             "path-is-absolute": {
               "version": "1.0.1",
-              "from": "path-is-absolute@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
             }
           }
         },
         "lodash": {
           "version": "4.17.4",
-          "from": "lodash@>=4.8.0 <5.0.0",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
         },
         "readable-stream": {
           "version": "2.2.9",
-          "from": "readable-stream@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
           "dependencies": {
             "buffer-shims": {
               "version": "1.0.0",
-              "from": "buffer-shims@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
             },
             "core-util-is": {
               "version": "1.0.2",
-              "from": "core-util-is@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
             },
             "isarray": {
               "version": "1.0.0",
-              "from": "isarray@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
             },
             "inherits": {
               "version": "2.0.3",
-              "from": "inherits@>=2.0.1 <2.1.0",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
             },
             "process-nextick-args": {
               "version": "1.0.7",
-              "from": "process-nextick-args@>=1.0.6 <1.1.0",
+              "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
               "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
             },
             "string_decoder": {
               "version": "1.0.0",
-              "from": "string_decoder@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz"
             },
             "util-deprecate": {
               "version": "1.0.2",
-              "from": "util-deprecate@>=1.0.1 <1.1.0",
+              "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
             }
           }
         },
         "tar-stream": {
           "version": "1.5.4",
-          "from": "tar-stream@>=1.5.0 <2.0.0",
+          "from": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.4.tgz",
           "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.4.tgz",
           "dependencies": {
             "bl": {
               "version": "1.2.1",
-              "from": "bl@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
               "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz"
             },
             "end-of-stream": {
               "version": "1.4.0",
-              "from": "end-of-stream@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
               "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
               "dependencies": {
                 "once": {
                   "version": "1.4.0",
-                  "from": "once@>=1.4.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.2",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                     }
                   }
@@ -194,41 +194,41 @@
             },
             "xtend": {
               "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <5.0.0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             }
           }
         },
         "zip-stream": {
           "version": "1.1.1",
-          "from": "zip-stream@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.1.1.tgz",
           "dependencies": {
             "compress-commons": {
               "version": "1.2.0",
-              "from": "compress-commons@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.2.0.tgz",
               "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.2.0.tgz",
               "dependencies": {
                 "crc32-stream": {
                   "version": "2.0.0",
-                  "from": "crc32-stream@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-2.0.0.tgz",
                   "dependencies": {
                     "crc": {
                       "version": "3.4.4",
-                      "from": "crc@>=3.4.4 <4.0.0",
+                      "from": "https://registry.npmjs.org/crc/-/crc-3.4.4.tgz",
                       "resolved": "https://registry.npmjs.org/crc/-/crc-3.4.4.tgz"
                     }
                   }
                 },
                 "normalize-path": {
                   "version": "2.1.1",
-                  "from": "normalize-path@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
                   "dependencies": {
                     "remove-trailing-separator": {
                       "version": "1.0.1",
-                      "from": "remove-trailing-separator@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz"
                     }
                   }
@@ -241,67 +241,67 @@
     },
     "async": {
       "version": "1.5.2",
-      "from": "async@1.5.2",
+      "from": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
     },
     "bluebird": {
       "version": "3.5.0",
-      "from": "bluebird@>=3.4.6 <4.0.0",
+      "from": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz"
     },
     "bson": {
       "version": "0.4.22",
-      "from": "bson@0.4.22",
+      "from": "https://registry.npmjs.org/bson/-/bson-0.4.22.tgz",
       "resolved": "https://registry.npmjs.org/bson/-/bson-0.4.22.tgz"
     },
     "csvtojson": {
       "version": "0.3.6",
-      "from": "csvtojson@0.3.6",
+      "from": "https://registry.npmjs.org/csvtojson/-/csvtojson-0.3.6.tgz",
       "resolved": "https://registry.npmjs.org/csvtojson/-/csvtojson-0.3.6.tgz"
     },
     "jcsv": {
       "version": "0.0.3",
-      "from": "jcsv@0.0.3",
+      "from": "https://registry.npmjs.org/jcsv/-/jcsv-0.0.3.tgz",
       "resolved": "https://registry.npmjs.org/jcsv/-/jcsv-0.0.3.tgz"
     },
     "lodash": {
       "version": "2.4.1",
-      "from": "lodash@2.4.1",
+      "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
     },
     "mongodb": {
       "version": "2.1.18",
-      "from": "mongodb@2.1.18",
+      "from": "https://registry.npmjs.org/mongodb/-/mongodb-2.1.18.tgz",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.1.18.tgz",
       "dependencies": {
         "es6-promise": {
           "version": "3.0.2",
-          "from": "es6-promise@3.0.2",
+          "from": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
           "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz"
         },
         "mongodb-core": {
           "version": "1.3.18",
-          "from": "mongodb-core@1.3.18",
+          "from": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-1.3.18.tgz",
           "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-1.3.18.tgz",
           "dependencies": {
             "bson": {
               "version": "0.4.23",
-              "from": "bson@>=0.4.23 <0.5.0",
+              "from": "https://registry.npmjs.org/bson/-/bson-0.4.23.tgz",
               "resolved": "https://registry.npmjs.org/bson/-/bson-0.4.23.tgz"
             },
             "require_optional": {
               "version": "1.0.0",
-              "from": "require_optional@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.0.tgz",
               "dependencies": {
                 "semver": {
                   "version": "5.3.0",
-                  "from": "semver@>=5.1.0 <6.0.0",
+                  "from": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
                 },
                 "resolve-from": {
                   "version": "2.0.0",
-                  "from": "resolve-from@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz"
                 }
               }
@@ -310,27 +310,27 @@
         },
         "readable-stream": {
           "version": "1.0.31",
-          "from": "readable-stream@1.0.31",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz",
           "dependencies": {
             "core-util-is": {
               "version": "1.0.2",
-              "from": "core-util-is@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
             },
             "isarray": {
               "version": "0.0.1",
-              "from": "isarray@0.0.1",
+              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
             },
             "string_decoder": {
               "version": "0.10.31",
-              "from": "string_decoder@>=0.10.0 <0.11.0",
+              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
             },
             "inherits": {
               "version": "2.0.3",
-              "from": "inherits@>=2.0.1 <2.1.0",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
             }
           }
@@ -339,7 +339,7 @@
     },
     "stream-buffers": {
       "version": "3.0.0",
-      "from": "stream-buffers@3.0.0",
+      "from": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-3.0.0.tgz"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-db",
   "description": "FeedHenry Database Library",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:feedhenry/fh-db.git"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-db
 sonar.projectName=fh-db-nightly-master
-sonar.projectVersion=2.0.1
+sonar.projectVersion=2.1.0
 
 sonar.sources=./lib
 sonar.tests=./test

--- a/test/test_ditcher.js
+++ b/test/test_ditcher.js
@@ -412,7 +412,6 @@ var testBasicOperationsOwnDatabase = function(cb){
                   testList9,
                   testList10,
                   testList11,
-                  testList12,
                   testListLimit,
                   testListSkip,
                   testListSort,
@@ -586,7 +585,7 @@ var testList1 = function(cb) {
     "__fhdb" : test_fhdb_name,
     "type" : "fh_test_list",
     "eq" : {
-      "foo" : "foo"
+      "foo" : {value: "foo", type: "String"}
     }
   };
 
@@ -609,7 +608,7 @@ var testList2 = function (cb) {
     "__fhdb" : test_fhdb_name,
     "type" : "fh_test_list",
     "ne" : {
-      "foo" : "foo"
+      "foo": { value: "foo", type: "String" }
     }
   };
 
@@ -630,7 +629,7 @@ var testList3 = function (cb) {
     "__fhdb" : test_fhdb_name,
     "type" : "fh_test_list",
     "gt" : {
-      "num2" : 400
+      "num2" : {value: 400, type: "Number"}
     }
   };
 
@@ -651,7 +650,7 @@ var testList4 = function (cb) {
     "__fhdb" : test_fhdb_name,
     "type" : "fh_test_list",
     "ge" : {
-      "num2" : 400
+      "num2": { value: 400, type: "Number" }
     }
   };
 
@@ -672,7 +671,7 @@ var testList5 = function(cb) {
     "__fhdb" : test_fhdb_name,
     "type" : "fh_test_list",
     "lt" : {
-      "num2" : 400
+      "num2": { value: 400, type: "Number" }
     }
   };
 
@@ -693,7 +692,7 @@ var testList6 = function(cb) {
     "__fhdb" : test_fhdb_name,
     "type" : "fh_test_list",
     "le" : {
-      "num2" : 400
+      "num2": { value: 400, type: "Number" }
     }
   };
 
@@ -715,7 +714,7 @@ var testList7 = function(cb) {
     "__fhdb" : test_fhdb_name,
     "type" : "fh_test_list",
     "like" : {
-      "liker" : "^123$"
+      "liker" : {value: "^123$", type: "String"}
     }
   };
 
@@ -738,7 +737,7 @@ var testList8 = function(cb) {
     "__fhdb" : test_fhdb_name,
     "type" : "fh_test_list",
     "like" : {
-      "liker" : "123"
+      "liker" : {value: "123", type: "String"}
     }
   };
 
@@ -760,7 +759,7 @@ var testList9 = function(cb) {
     "__fhdb" : test_fhdb_name,
     "type" : "fh_test_list",
     "like" : {
-      "liker" : "def"
+      "liker" : {value: "def", type: "String"}
     }
   };
 
@@ -782,7 +781,7 @@ var testList10 = function(cb) {
     "__fhdb" : test_fhdb_name,
     "type" : "fh_test_list",
     "like" : {
-      "liker" : "def$"
+      "liker" : {value: "def$", type: "String"}
     }
   };
 
@@ -806,11 +805,8 @@ var testList11 = function (cb) {
     "__fhdb" : test_fhdb_name,
     "type" : "fh_test_list",
     "gt" : {
-      "num1" : 100,
-      "num2" : 400
-    },
-    "lt" : {
-      "num1" : 130
+      "num1" : {value: 100, type: "Number"},
+      "num2" : {value: 400, type: "Number"}
     }
   };
 
@@ -819,34 +815,12 @@ var testList11 = function (cb) {
   }
 
   ditch.doList(doListRequest, function (err, listGtltRes) {
-    assert.equal(listGtltRes.length, 1);
+    assert.equal(listGtltRes.length, 2);
     assert.equal(listGtltRes[0].fields.idx, 2);
+    assert.equal(listGtltRes[1].fields.idx, 4);
     cb();
   });
 };
-
-var testList12 = function (cb){
-  logger.info("test testList12()");
-
-
-  var doListRequest = {
-    "__fhdb": test_fhdb_name,
-    "type": 'fh_test_list',
-    "in" : {
-      "num1": [100, 110, 120],
-      "liker": ['123', 'abcdef']
-    }
-  };
-
-  if(useOwnDatabase){
-    doListRequest.__dbperapp = true;
-  }
-
-  ditch.doList(doListRequest, function (err, listInRes) {
-      assert.equal(listInRes.length, 2);
-      cb();
-  });
-}
 
 var testListLimit = function (cb){
   logger.info("test testListLimit()");
@@ -1372,7 +1346,6 @@ exports.testDbActions = function(done) {
         testList9,
         testList10,
         testList11,
-        testList12,
         testBadCreate,
         testBadCreateNoFields,
         testBadCreate2,


### PR DESCRIPTION
## Motivation
Users can't filter documents by `_id` in the databrowser.

## Result
Add in the ability to filter documents with `Date`, `Any` or `ObjectId` type.

Note: included in this is the removal of the `$in` query option as it is no longer used.

## Jira
https://issues.jboss.org/browse/RHMAP-13690