### PR TITLE
🐛 RHMAP-16889 Allow mongodb connection string to work without auth

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -7,17 +7,25 @@ var assert = require("assert");
  * @returns Configuration Object
  */
 exports.parseMongoConnectionURL = function (mongoConnectionURL) {
-  var result = {};
+  var result = {
+    database: {
+      driver_options: {}
+    }
+  };
 
   //The connection string will be of the form mongodb://user:password@host:port,host2port2/databasename?option=someOption
   //String to break down the mongodb url into a ditch config hash
   var auth_hosts_path_options = new Buffer(mongoConnectionURL).toString().split("//")[1];
+  var hosts_path_options = auth_hosts_path_options;
+  var auth = null;
 
-  //user:password , host:port,host2:port2/databasename?option=someOption
-  var auth = auth_hosts_path_options.split("@")[0];
-
-
-  var hosts_path_options = auth_hosts_path_options.split("@")[1];
+  // If auth is included, split that from the rest of the string
+  // and configure the auth config
+  if (auth_hosts_path_options.indexOf("@") > -1) {
+    //user:password , host:port,host2:port2/databasename?option=someOption
+    auth = auth_hosts_path_options.split("@")[0];
+    hosts_path_options = auth_hosts_path_options.split("@")[1];
+  }
 
   // host:port,host2:port2/databasename , option=someOption
   var hosts_path = hosts_path_options.split("?")[0];
@@ -30,21 +38,21 @@ exports.parseMongoConnectionURL = function (mongoConnectionURL) {
   //host:port host2:port2
   var hostList = hosts.split(",");
 
-  //user, password
-  var authUser = auth.split(":")[0];
-  var authPassword = auth.split(":")[1];
-
-  result.database = {};
-  result.database.driver_options = {};
-  result.database.auth = {};
-  result.database.auth.user = authUser;
-  result.database.auth.pass = authPassword;
-  result.database.auth.source = databaseName;
   result.database.name = databaseName;
 
-  assert.ok(authUser !== undefined);
-  assert.ok(authPassword !== undefined);
   assert.ok(databaseName !== undefined);
+
+  if (auth) {
+    //user, password
+    var authUser = auth.split(":")[0];
+    var authPassword = auth.split(":")[1];
+
+    result.database.auth = {
+      user: authUser,
+      pass: authPassword,
+      source: databaseName
+    };
+  }
 
   //Parsing options
   if (options) {
@@ -94,8 +102,6 @@ exports.parseMongoConnectionURL = function (mongoConnectionURL) {
 
   //Verify the config to be returned
   assert.ok(result.database.name.length > 0);
-  assert.ok(result.database.auth.user.length > 0);
-  assert.ok(result.database.auth.pass.length > 0);
 
 
   return result;


### PR DESCRIPTION
This addresses the following error when using fh-db (via fh-mbaas-api)
for local development i.e. when FH_USE_LOCAL_DB is true:

```
    LOCALDB error Error: Incorrect format for database connection string.
```

The actual error & stack is captured here.
https://gist.github.com/david-martin/eb96556f07ef05d8441238e70983d197
The mongo string parsing function is making the assumption that there is
an `@` symbol i.e. a user & password is specified before the mongodb
host.

The fix checks for the existense of the `@` symbol before tyring to
split the string and use parts of it