### PR TITLE
version bump

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-db",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "dependencies": {
     "adm-zip": {
       "version": "0.4.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-db",
   "description": "FeedHenry Database Library",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:feedhenry/fh-db.git"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-db
 sonar.projectName=fh-db-nightly-master
-sonar.projectVersion=2.1.0
+sonar.projectVersion=3.0.0
 
 sonar.sources=./lib
 sonar.tests=./test


### PR DESCRIPTION
Must make a major version bump because of the changes introduced [here](https://github.com/feedhenry/fh-db/pull/29).  The structure of the query changed and therefore is not backward compatible