### PR TITLE
task(fix arbitrary file write vulnerability): RHMAP-20777

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "3.3.0",
   "dependencies": {
     "adm-zip": {
-      "version": "0.4.7",
-      "from": "adm-zip@>=0.4.4 <0.5.0",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz"
+      "version": "0.4.11",
+      "from": "adm-zip@0.4.11",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.11.tgz"
     },
     "archiver": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-db",
   "description": "FeedHenry Database Library",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "repository": {
     "type": "git",
     "url": "git@github.com:feedhenry/fh-db.git"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "node": "4.4"
   },
   "dependencies": {
-    "adm-zip": "~0.4.4",
+    "adm-zip": "0.4.11",
     "archiver": "1.0.0",
     "async": "1.5.2",
     "bluebird": "^3.4.6",


### PR DESCRIPTION
# Jira:
https://issues.jboss.org/browse/RHMAP-20777

# What:
* Upgrade version of adm-zip

# Why:
A vulnerability has been found in the way developers have implemented the archive extraction of files. An arbitrary file write vulnerability, that can be achieved using a specially crafted zip archive (affects other archives as well, bzip2, tar,xz, war, cpio, 7z), that holds path traversal filenames. So when the filename gets concatenated to the target extraction directory, the final path ends up outside of the target folder. Of course if an executable or a configuration file is overwritten with a file containing malicious code, the problem can turn into an arbitrary code execution issue quite easily. This affects multiple libraries that lacks of a high level APIs that provide the archive extraction functionality.

References:

- https://github.com/cthackers/adm-zip/pull/212
- https://github.com/cthackers/adm-zip/commit/6f4dfeb9a2166e93207443879988f97d88a37cde
- https://github.com/cthackers/adm-zip/pull/215
- https://github.com/cthackers/adm-zip/commit/ce59e5a05a0dc1e31ca2f4ae43ae8d50a2f0920a
- https://github.com/cthackers/adm-zip/issues/176
- https://github.com/cthackers/adm-zip/commit/3f00a03ff55a1e1643b690a67fbe164e9ed7f48a
 
# How:
Upgrade lib from `~0.4.4` to `0.4.11`

# Checks:
* This upgrade has not break changes. 
* Check if the CI will finish with success.
