### PR TITLE
[WIP] Add Date object support to db API

### DIFF
--- a/lib/localdb.js
+++ b/lib/localdb.js
@@ -4,6 +4,7 @@ var assert = require('assert');
 var permission_map = require('./permission_map');
 var parseMongoConnectionURL = require('./utils').parseMongoConnectionURL;
 var my_db_logger = require("./logger");
+var translateObjects = require("../lib/translateobjects.js").translateObjects;
 
 var ditch;
 
@@ -59,6 +60,8 @@ var tearDownDitch = function () {
 
 var local_db = function (params, cb) {
   var action = params.act;
+
+  params.fields = translateObjects(params.fields);
 
   getDitchHandle(function (err) {
     if (err) {

--- a/lib/translateobjects.js
+++ b/lib/translateobjects.js
@@ -1,0 +1,24 @@
+var _ = require('lodash');
+
+function translateObjects(fields) {
+    var ret = fields;
+    if (fields) {
+        _.forOwn(fields, function(val,key,obj) {
+            if(val['$date']) {
+                var orig = val['$date']
+                var converted = new Date(val['$date'])
+                try {
+                    converted.toISOString() // ensure valid date
+                    obj[key] = converted
+                }
+                catch (e){
+                    // if invalid date use the value as passed 
+                    obj[key] = orig
+                }
+            }
+        });
+    }
+    return ret;
+}
+
+exports.translateObjects = translateObjects;

--- a/test/test_translateobjects.js
+++ b/test/test_translateobjects.js
@@ -1,0 +1,55 @@
+var assert = require('assert');
+var translateObjects = require("../lib/translateobjects.js").translateObjects;
+
+
+exports['test no translation'] = function (done) {
+    var translated = translateObjects({
+        "firstName" : "Joe",
+        "when" : "2018-10-08T16:44:39.503Z"
+    });
+    assert.ok(translated, 'unexpected null value returned');
+    assert.equal(translated.firstName, "Joe")
+    assert.equal(typeof translated.when, "string")
+    assert.ok(translated.when, "2018-10-08T16:44:39.503Z")
+    done();
+}
+
+exports['test empty params'] = function (done) {
+    var translated = translateObjects({});
+    assert.ok(translated, 'expected object returned');
+
+    translated = translateObjects();
+    assert.ok(!translated, "expected null/undefined returned");
+    done();
+}
+
+exports['test translate date'] = function (done) {
+    var translated = translateObjects({
+        "firstName" : "Joe",
+        "when" : {
+            $date: "2018-10-08T16:44:39.503Z"
+        }
+    });
+    assert.ok(translated, 'expected object to be returned');
+    assert.equal(translated.firstName, "Joe");
+    assert.equal(typeof translated.when, "object");
+    assert.ok(translated.when instanceof Date, 'expected when field to be an instances of Date object')
+    assert.equal(translated.when.getMinutes(), 44)
+    assert.equal(translated.when.toISOString(), "2018-10-08T16:44:39.503Z")
+    done();
+}
+
+exports['test translate with invalid date'] = function (done) {
+    var translated = translateObjects({
+        "firstName" : "Joe",
+        "when" : {
+            $date: "Jim"
+        }
+    });
+    assert.ok(translated, 'unexpected null value returned');
+    assert.equal(translated.firstName, "Joe")
+    assert.equal(typeof translated.when, "string")
+    assert.ok(translated.when, "Jim")
+    done();
+}
+


### PR DESCRIPTION
allow converting dates that come from JSON strings to Date Objects
e.g.
```
  "fields": {
    "name": "Joe Bloggs",
    "DOB": { "$date": "2000-02-29T00:00:00Z" }
  }
```
would change the `DOB` field to `new Date("2000-02-29T00:00:00Z")`

invalid dates use the value that was passed instead of a `Date` Object
e.g.
```
  "fields": {
    "name": "Joe Bloggs",
    "DOB": { "$date": "Jim" }
  }
```
would change the `DOB` field to ` "Jim"`