### PR TITLE
[WIP] Add date support for read

### DIFF
--- a/lib/ditcher.js
+++ b/lib/ditcher.js
@@ -3,6 +3,7 @@ var EventEmitter = require('events').EventEmitter;
 var util = require("util");
 var async = require('async');
 var convert = require('./convert_query_type.js');
+var _ = require('lodash');
 var translateDateObject = require("../lib/translateobjects.js").translateDateObject;
 
 var MAX_COLLECTION_NAME = 70;
@@ -186,7 +187,7 @@ function generateReturn(document, type) {
 }
 
 function translateObjectsEnabled() {
-  return process.env.FH_SERIALISE_DATES === "yes"
+  return _.indexOf(["YES", "TRUE"], _.toUpper(process.env.FH_SERIALISE_DATES)) >= 0
 }
 
 Ditcher.prototype.translateObjectsEnabled = translateObjectsEnabled;

--- a/lib/ditcher.js
+++ b/lib/ditcher.js
@@ -187,7 +187,7 @@ function generateReturn(document, type) {
 }
 
 function translateObjectsEnabled() {
-  return process.env.FH_SERIALISE_DATES && _.indexOf(["YES", "TRUE"], process.env.FH_SERIALISE_DATES.toUpperCase()) >= 0
+  return process.env.SERIALISE_FH_DATES && _.indexOf(["YES", "TRUE"], process.env.SERIALISE_FH_DATES.toUpperCase()) >= 0
 }
 
 Ditcher.prototype.translateObjectsEnabled = translateObjectsEnabled;

--- a/lib/ditcher.js
+++ b/lib/ditcher.js
@@ -187,7 +187,7 @@ function generateReturn(document, type) {
 }
 
 function translateObjectsEnabled() {
-  return _.indexOf(["YES", "TRUE"], _.toUpper(process.env.FH_SERIALISE_DATES)) >= 0
+  return process.env.FH_SERIALISE_DATES && _.indexOf(["YES", "TRUE"], process.env.FH_SERIALISE_DATES.toUpperCase()) >= 0
 }
 
 Ditcher.prototype.translateObjectsEnabled = translateObjectsEnabled;

--- a/lib/ditcher.js
+++ b/lib/ditcher.js
@@ -3,6 +3,8 @@ var EventEmitter = require('events').EventEmitter;
 var util = require("util");
 var async = require('async');
 var convert = require('./convert_query_type.js');
+var translateDateObject = require("../lib/translateobjects.js").translateDateObject;
+
 var MAX_COLLECTION_NAME = 70;
 // If not single db per app, we need to be passed a valid AppName string, otherwise could be manipulating into listing anything
 var appname_regex = /.+-[a-zA-Z0-9]{24}-/;
@@ -172,12 +174,22 @@ function generateReturn(document, type) {
           retDoc.fields = {};
           i = 1;
         }
-        retDoc.fields[field] = document[field];
+        if(translateObjectsEnabled()) {
+          retDoc.fields[field] = translateDateObject(document[field]);
+        } else {
+          retDoc.fields[field] = document[field];
+        }
       }
     }
   }
   return retDoc;
 }
+
+function translateObjectsEnabled() {
+  return process.env.FH_SERIALISE_DATES === "yes"
+}
+
+Ditcher.prototype.translateObjectsEnabled = translateObjectsEnabled;
 
 Ditcher.prototype.tearDown = function () {
   var self = this;

--- a/lib/localdb.js
+++ b/lib/localdb.js
@@ -67,9 +67,8 @@ var local_db = function (params, cb) {
     }
     my_db_logger.debug("DBACTION: " + action);
 
-    if (ditch.translateObjectsEnabled()) {
-      params.fields = translateObjects(params.fields);
-    }
+
+    params.fields = translateObjects(params.fields);
     
     // Using the `name` property from the permission map here to make
     // sure this one gets updated as new actions are added.

--- a/lib/localdb.js
+++ b/lib/localdb.js
@@ -4,6 +4,7 @@ var assert = require('assert');
 var permission_map = require('./permission_map');
 var parseMongoConnectionURL = require('./utils').parseMongoConnectionURL;
 var my_db_logger = require("./logger");
+var translateObjects = require("../lib/translateobjects.js").translateObjects;
 
 var ditch;
 
@@ -59,6 +60,8 @@ var tearDownDitch = function () {
 
 var local_db = function (params, cb) {
   var action = params.act;
+
+  params.fields = translateObjects(params.fields);
 
   getDitchHandle(function (err) {
     if (err) {

--- a/lib/localdb.js
+++ b/lib/localdb.js
@@ -61,14 +61,16 @@ var tearDownDitch = function () {
 var local_db = function (params, cb) {
   var action = params.act;
 
-  params.fields = translateObjects(params.fields);
-
   getDitchHandle(function (err) {
     if (err) {
       return cb(err);
     }
     my_db_logger.debug("DBACTION: " + action);
 
+    if (ditch.translateObjectsEnabled()) {
+      params.fields = translateObjects(params.fields);
+    }
+    
     // Using the `name` property from the permission map here to make
     // sure this one gets updated as new actions are added.
     if ('getDitcher' === action) {

--- a/lib/translateobjects.js
+++ b/lib/translateobjects.js
@@ -1,5 +1,5 @@
 var _ = require('lodash');
-var dateMetaFieldName = "$date";
+var dateMetaFieldName = process.env.SERIALISE_FH_DATES_KEY || "$fhdate";
 
 function translateObjects(fields) {
     var ret = fields;

--- a/lib/translateobjects.js
+++ b/lib/translateobjects.js
@@ -1,0 +1,24 @@
+var _ = require('lodash');
+
+function translateObjects(fields) {
+    var ret = fields;
+    if (fields) {
+        _.forOwn(fields, function(val,key,obj) {
+            if(val['$date']) {
+                var orig = val['$date']
+                var converted = new Date(val['$date'])
+                try {
+                    converted.toISOString() // ensure valid date
+                    obj[key] = converted
+                }
+                catch (e){
+                    // if invalid date use the value as passed 
+                    obj[key] = orig
+                }
+            }
+        });
+    }
+    return ret;
+}
+
+exports.translateObjects = translateObjects;

--- a/lib/translateobjects.js
+++ b/lib/translateobjects.js
@@ -1,12 +1,13 @@
 var _ = require('lodash');
+var dateMetaFieldName = "$date";
 
 function translateObjects(fields) {
     var ret = fields;
     if (fields) {
         _.forOwn(fields, function(val,key,obj) {
-            if(val['$date']) {
-                var orig = val['$date']
-                var converted = new Date(val['$date'])
+            if(val[dateMetaFieldName]) {
+                var orig = val[dateMetaFieldName]
+                var converted = new Date(val[dateMetaFieldName])
                 try {
                     converted.toISOString() // ensure valid date
                     obj[key] = converted
@@ -21,4 +22,14 @@ function translateObjects(fields) {
     return ret;
 }
 
+function translateDateObject(field) {
+    var ret = field;
+    if (field instanceof Date) {
+        ret = {}
+        ret[dateMetaFieldName] = field.toISOString();
+    }
+    return ret;
+}
+
+exports.translateDateObject = translateDateObject;
 exports.translateObjects = translateObjects;

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-db",
-  "version": "3.3.0",
+  "version": "3.3.2",
   "dependencies": {
     "adm-zip": {
       "version": "0.4.11",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-db",
   "description": "FeedHenry Database Library",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "repository": {
     "type": "git",
     "url": "git@github.com:feedhenry/fh-db.git"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-db
 sonar.projectName=fh-db-nightly-master
-sonar.projectVersion=3.3.0
+sonar.projectVersion=3.3.2
 
 sonar.sources=./lib
 sonar.tests=./test

--- a/test/test_translateobjects.js
+++ b/test/test_translateobjects.js
@@ -1,9 +1,9 @@
 var assert = require('assert');
-var translateObjects = require("../lib/translateobjects.js").translateObjects;
+var translateObjects = require("../lib/translateobjects.js");
 
 
 exports['test no translation'] = function (done) {
-    var translated = translateObjects({
+    var translated = translateObjects.translateObjects({
         "firstName" : "Joe",
         "when" : "2018-10-08T16:44:39.503Z"
     });
@@ -15,16 +15,16 @@ exports['test no translation'] = function (done) {
 }
 
 exports['test empty params'] = function (done) {
-    var translated = translateObjects({});
+    var translated = translateObjects.translateObjects({});
     assert.ok(translated, 'expected object returned');
 
-    translated = translateObjects();
+    translated = translateObjects.translateObjects();
     assert.ok(!translated, "expected null/undefined returned");
     done();
 }
 
 exports['test translate date'] = function (done) {
-    var translated = translateObjects({
+    var translated = translateObjects.translateObjects({
         "firstName" : "Joe",
         "when" : {
             $date: "2018-10-08T16:44:39.503Z"
@@ -40,7 +40,7 @@ exports['test translate date'] = function (done) {
 }
 
 exports['test translate with invalid date'] = function (done) {
-    var translated = translateObjects({
+    var translated = translateObjects.translateObjects({
         "firstName" : "Joe",
         "when" : {
             $date: "Jim"
@@ -53,3 +53,19 @@ exports['test translate with invalid date'] = function (done) {
     done();
 }
 
+
+exports['test field to meta, with no date'] = function (done) {
+    var translated = translateObjects.translateDateObject("hello");
+    assert.ok(translated, 'unexpected null value returned');
+    assert.equal(translated, "hello")
+    done();
+}
+
+exports['test field to meta, with date'] = function (done) {
+    var translated = translateObjects.translateDateObject(new Date("2018-10-08T16:44:39.503Z"));
+    assert.ok(translated, 'expected object to be returned');
+    assert.equal(typeof translated, "object");
+    assert.ok(translated["$date"], 'expected $date meta field')
+    assert.equal(translated["$date"], "2018-10-08T16:44:39.503Z")
+    done();
+}

--- a/test/test_translateobjects.js
+++ b/test/test_translateobjects.js
@@ -1,0 +1,55 @@
+var assert = require('assert');
+var translateObjects = require("../lib/translateobjects.js").translateObjects;
+
+
+exports['test no translation'] = function (done) {
+    var translated = translateObjects({
+        "firstName" : "Joe",
+        "when" : "2018-10-08T16:44:39.503Z"
+    });
+    assert.ok(translated, 'unexpected null value returned');
+    assert.equal(translated.firstName, "Joe")
+    assert.equal(typeof translated.when, "string")
+    assert.ok(translated.when, "2018-10-08T16:44:39.503Z")
+    done();
+}
+
+exports['test empty params'] = function (done) {
+    var translated = translateObjects({});
+    assert.ok(translated, 'expected object returned');
+
+    translated = translateObjects();
+    assert.ok(!translated, "expected null/undefined returned");
+    done();
+}
+
+exports['test translate date'] = function (done) {
+    var translated = translateObjects({
+        "firstName" : "Joe",
+        "when" : {
+            $date: "2018-10-08T16:44:39.503Z"
+        }
+    });
+    assert.ok(translated, 'expected object to be returned');
+    assert.equal(translated.firstName, "Joe");
+    assert.equal(typeof translated.when, "object");
+    assert.ok(translated.when instanceof Date, 'expected when field to be an instances of Date object')
+    assert.equal(translated.when.getMinutes(), 44)
+    assert.equal(translated.when.toISOString(), "2018-10-08T16:44:39.503Z")
+    done();
+}
+
+exports['test translate with invalid date'] = function (done) {
+    var translated = translateObjects({
+        "firstName" : "Joe",
+        "when" : {
+            $date: "Jim"
+        }
+    });
+    assert.ok(translated, 'unexpected null value returned');
+    assert.equal(translated.firstName, "Joe")
+    assert.equal(typeof translated.when, "string")
+    assert.ok(translated.when, "Jim")
+    done();
+}
+

--- a/test/test_translateobjects.js
+++ b/test/test_translateobjects.js
@@ -27,7 +27,7 @@ exports['test translate date'] = function (done) {
     var translated = translateObjects.translateObjects({
         "firstName" : "Joe",
         "when" : {
-            $date: "2018-10-08T16:44:39.503Z"
+            $fhdate: "2018-10-08T16:44:39.503Z"
         }
     });
     assert.ok(translated, 'expected object to be returned');
@@ -43,7 +43,7 @@ exports['test translate with invalid date'] = function (done) {
     var translated = translateObjects.translateObjects({
         "firstName" : "Joe",
         "when" : {
-            $date: "Jim"
+            $fhdate: "Jim"
         }
     });
     assert.ok(translated, 'unexpected null value returned');
@@ -65,7 +65,7 @@ exports['test field to meta, with date'] = function (done) {
     var translated = translateObjects.translateDateObject(new Date("2018-10-08T16:44:39.503Z"));
     assert.ok(translated, 'expected object to be returned');
     assert.equal(typeof translated, "object");
-    assert.ok(translated["$date"], 'expected $date meta field')
-    assert.equal(translated["$date"], "2018-10-08T16:44:39.503Z")
+    assert.ok(translated["$fhdate"], 'expected $fhdate meta field')
+    assert.equal(translated["$fhdate"], "2018-10-08T16:44:39.503Z")
     done();
 }


### PR DESCRIPTION
# Jira link(s)
https://issues.jboss.org/browse/RHMAP-21771


# What
When a date field is present in a document in a collection in RHMAP, altering the document manually in the data browser directly in studio causes the date field to be saved as type string instead of type Date. This can effect how the field is used in its app (e.g. When the field is used as search criteria during a database search).

# Why
All Date formats are getting saved as Strings when a user edits a row in the databrowser.

# How
Allow Date objects in the database to be transferred and displayed/saved in DateBrowser as javascript objects as follows:
```
{
   $fhdate: "2018-10-10T11:54:12.366Z"
}
```

fh.db will check for $fhdate and save the field type as a Date in the database.

To read the fields from the database in the same format. The environment variable needs to be set in the app.

```
process.env.SERIALISE_FH_DATES=true
```

# Verification Steps
**Note:** 
* To create a new entry in the db, restart the app. 
* To check the actual type of the value in the database, hit this url https://support-ng463itjv42t2myz6jnpkjzw-dev.mbaas1.eu.feedhenry.com/hello and check the output in the app logs here - https://support.eu.feedhenry.com/#projects/ng463isi7so2jzakpoort72q/apps/ng463itjv42t2myz6jnpkjzw/logs

1. Check value types are all Dates (see note above)
1. Go to https://support.eu.feedhenry.com/#projects/ng463isi7so2jzakpoort72q/apps/ng463itjv42t2myz6jnpkjzw/databrowser . Edit a row and save.
1. Check value types, one should now be a string.
1. go to databrowser and click advanced editor on any row. Click raw and change the "when" key and value to `"when": {"$fhdate", "2018-10-15T15:49:09.746Z"},`. Click save
1. Check value types, the saved row should be a Date
1. Go to environment variables and add a new env var with the name SERIALISE_FH_DATES and value true.
1. All Dates in the databrowser should now show as Objects and can only be edited in advanced editor mode
1. Edit dates and check the value types to ensure they stay as Dates.
 

## Checklist:
- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 